### PR TITLE
gui: Copy HTML and Markdown to the clipboard. #9

### DIFF
--- a/gui/src/clipboard.rs
+++ b/gui/src/clipboard.rs
@@ -2,6 +2,10 @@ use std::io::Cursor;
 
 use tdoc::{Document, html, markdown};
 
+use crate::richtext::markdown_converter::{
+    document_to_html, document_to_markdown, markdown_to_document,
+};
+use crate::richtext::structured_document::StructuredDocument;
 use crate::rtf;
 
 #[derive(Debug)]
@@ -124,6 +128,54 @@ fn document_from_html(html_content: &str) -> Result<Document, ClipboardDocumentE
 
     html::parse(Cursor::new(html_content.as_bytes()))
         .map_err(|err| ClipboardDocumentError::Parse(err.to_string()))
+}
+
+/// Copy a structured selection to the system clipboard.
+///
+/// Places HTML on the clipboard for rich-text-aware targets, with the Markdown
+/// serialization as the plain-text alternative so plain-text (and
+/// Markdown-aware) targets get a useful representation too. Falls back to a
+/// plain-text Markdown copy via FLTK when the system clipboard is unavailable.
+pub fn copy_structured_to_system(doc: &StructuredDocument) {
+    let markdown = document_to_markdown(doc);
+    let html = document_to_html(doc);
+    place_on_clipboard(&markdown, &html);
+}
+
+/// Copy raw Markdown text (from the plain Markdown editor) to the system
+/// clipboard, rendering HTML for rich-text targets while keeping the original
+/// Markdown text as the plain-text alternative.
+pub fn copy_markdown_to_system(markdown: &str) {
+    let html = document_to_html(&markdown_to_document(markdown));
+    place_on_clipboard(markdown, &html);
+}
+
+/// Write `html` (with `markdown` as the plain-text alternative) to the system
+/// clipboard, falling back to a plain-text copy through FLTK when arboard is
+/// unavailable or the HTML payload is empty.
+fn place_on_clipboard(markdown: &str, html: &str) {
+    let wrote_html = !html.trim().is_empty() && write_html_with_alt(markdown, html);
+    if !wrote_html {
+        fltk::app::copy(markdown);
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+fn write_html_with_alt(markdown: &str, html: &str) -> bool {
+    use arboard::Clipboard;
+
+    match Clipboard::new().and_then(|mut clipboard| clipboard.set().html(html, Some(markdown))) {
+        Ok(()) => true,
+        Err(err) => {
+            eprintln!("[piki] Failed to copy HTML to clipboard: {err}");
+            false
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+fn write_html_with_alt(_markdown: &str, _html: &str) -> bool {
+    false
 }
 
 fn log_formats(formats: &[String]) {

--- a/gui/src/fltk_structured_rich_display.rs
+++ b/gui/src/fltk_structured_rich_display.rs
@@ -497,8 +497,14 @@ impl FltkStructuredRichDisplay {
                                     let change_cb = change_cb.clone();
                                     let mut w_r = w_for_actions.clone();
                                     move || {
-                                        if let Ok(text) = display.borrow_mut().editor_mut().cut() {
-                                            fltk::app::copy(&text);
+                                        let doc =
+                                            display.borrow().editor().get_selection_document();
+                                        if let Some(doc) = doc {
+                                            clipboard::copy_structured_to_system(&doc);
+                                            let _ = display
+                                                .borrow_mut()
+                                                .editor_mut()
+                                                .delete_selection();
                                         }
                                         if let Some(cb) = &mut *change_cb.borrow_mut() {
                                             (cb)();
@@ -509,9 +515,10 @@ impl FltkStructuredRichDisplay {
                                 copy: Box::new({
                                     let display = display.clone();
                                     move || {
-                                        let text = display.borrow().editor().copy();
-                                        if !text.is_empty() {
-                                            fltk::app::copy(&text);
+                                        if let Some(doc) =
+                                            display.borrow().editor().get_selection_document()
+                                        {
+                                            clipboard::copy_structured_to_system(&doc);
                                         }
                                     }
                                 }),
@@ -1170,10 +1177,16 @@ impl FltkStructuredRichDisplay {
                                             let display = display.clone();
                                             let mut w_r = w_for_actions.clone();
                                             move || {
-                                                if let Ok(text) =
-                                                    display.borrow_mut().editor_mut().cut()
-                                                {
-                                                    fltk::app::copy(&text);
+                                                let doc = display
+                                                    .borrow()
+                                                    .editor()
+                                                    .get_selection_document();
+                                                if let Some(doc) = doc {
+                                                    clipboard::copy_structured_to_system(&doc);
+                                                    let _ = display
+                                                        .borrow_mut()
+                                                        .editor_mut()
+                                                        .delete_selection();
                                                 }
                                                 w_r.redraw();
                                             }
@@ -1181,9 +1194,12 @@ impl FltkStructuredRichDisplay {
                                         copy: Box::new({
                                             let display = display.clone();
                                             move || {
-                                                let text = display.borrow().editor().copy();
-                                                if !text.is_empty() {
-                                                    fltk::app::copy(&text);
+                                                if let Some(doc) = display
+                                                    .borrow()
+                                                    .editor()
+                                                    .get_selection_document()
+                                                {
+                                                    clipboard::copy_structured_to_system(&doc);
                                                 }
                                             }
                                         }),
@@ -1393,16 +1409,20 @@ impl FltkStructuredRichDisplay {
                                 }
                                 // Cmd/Ctrl-C (copy)
                                 else if cmd_modifier && key == Key::from_char('c') {
-                                    let text = display.borrow().editor().copy();
-                                    if !text.is_empty() {
-                                        fltk::app::copy(&text);
+                                    if let Some(doc) =
+                                        display.borrow().editor().get_selection_document()
+                                    {
+                                        clipboard::copy_structured_to_system(&doc);
                                     }
                                     handled = true;
                                 }
                                 // Cmd/Ctrl-X (cut)
                                 else if cmd_modifier && key == Key::from_char('x') {
-                                    if let Ok(text) = display.borrow_mut().editor_mut().cut() {
-                                        fltk::app::copy(&text);
+                                    let doc = display.borrow().editor().get_selection_document();
+                                    if let Some(doc) = doc {
+                                        clipboard::copy_structured_to_system(&doc);
+                                        let _ =
+                                            display.borrow_mut().editor_mut().delete_selection();
                                     }
                                     if let Some(cb) = &mut *change_cb.borrow_mut() {
                                         (cb)();

--- a/gui/src/menu.rs
+++ b/gui/src/menu.rs
@@ -830,12 +830,11 @@ fn perform_cut(
     active_editor: &Rc<RefCell<Rc<RefCell<dyn PageUI>>>>,
     is_structured: &Rc<RefCell<bool>>,
 ) {
-    if let Some(Some(text)) = with_structured_editor(active_editor, is_structured, true, |editor| {
+    if with_structured_editor(active_editor, is_structured, true, |editor| {
         editor.cut_selection()
-    }) {
-        if !text.is_empty() {
-            app::copy(&text);
-        }
+    })
+    .is_some()
+    {
         app::redraw();
         return;
     }
@@ -844,7 +843,7 @@ fn perform_cut(
         editor.cut_selection()
     }) {
         if !text.is_empty() {
-            app::copy(&text);
+            piki_gui::clipboard::copy_markdown_to_system(&text);
         }
         app::redraw();
     }
@@ -854,14 +853,11 @@ fn perform_copy(
     active_editor: &Rc<RefCell<Rc<RefCell<dyn PageUI>>>>,
     is_structured: &Rc<RefCell<bool>>,
 ) {
-    if let Some(Some(text)) =
-        with_structured_editor(active_editor, is_structured, false, |editor| {
-            editor.copy_selection()
-        })
+    if with_structured_editor(active_editor, is_structured, false, |editor| {
+        editor.copy_selection()
+    })
+    .is_some()
     {
-        if !text.is_empty() {
-            app::copy(&text);
-        }
         return;
     }
 
@@ -869,7 +865,7 @@ fn perform_copy(
         editor.copy_selection()
     }) && !text.is_empty()
     {
-        app::copy(&text);
+        piki_gui::clipboard::copy_markdown_to_system(&text);
     }
 }
 

--- a/gui/src/richtext/markdown_converter.rs
+++ b/gui/src/richtext/markdown_converter.rs
@@ -5,6 +5,7 @@ use super::structured_document::StructuredDocument;
 use super::tdoc_bridge::{structured_to_tdoc, tdoc_to_structured};
 use std::io::Cursor;
 use tdoc::markdown;
+use tdoc::writer::Writer;
 
 /// Convert markdown text to a [`StructuredDocument`].
 pub fn markdown_to_document(markdown: &str) -> StructuredDocument {
@@ -24,6 +25,22 @@ pub fn document_to_markdown(doc: &StructuredDocument) -> String {
         return String::new();
     }
     String::from_utf8(buffer).unwrap_or_default()
+}
+
+/// Convert a [`StructuredDocument`] into an HTML fragment.
+///
+/// Unlike markdown, the HTML output can represent every inline style the
+/// editor supports (e.g. underline and highlight), which makes it the richer
+/// representation for the system clipboard's `text/html` flavor.
+pub fn document_to_html(doc: &StructuredDocument) -> String {
+    let tdoc_doc = structured_to_tdoc(doc);
+    match Writer::new().write_to_string(&tdoc_doc) {
+        Ok(html) => html,
+        Err(err) => {
+            eprintln!("Failed to serialize document to HTML: {}", err);
+            String::new()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -82,6 +99,55 @@ mod tests {
 
         let markdown = document_to_markdown(&doc);
         assert_eq!(markdown.trim(), "Hello **world**");
+    }
+
+    #[test]
+    fn test_document_to_html_preserves_underline_and_highlight() {
+        // Underline and highlight cannot be represented in Markdown, so the
+        // HTML flavor is what carries them onto the clipboard.
+        let mut doc = StructuredDocument::new();
+        let mut block = Block::paragraph();
+        block.content.push(InlineContent::Text(TextRun::new(
+            "under",
+            TextStyle {
+                underline: true,
+                ..Default::default()
+            },
+        )));
+        block.content.push(InlineContent::Text(TextRun::new(
+            "mark",
+            TextStyle {
+                highlight: true,
+                ..Default::default()
+            },
+        )));
+        doc.add_block(block);
+
+        let html = document_to_html(&doc);
+        assert!(html.contains("<u>under</u>"), "html was: {html}");
+        assert!(html.contains("<mark>mark</mark>"), "html was: {html}");
+    }
+
+    #[test]
+    fn test_document_to_html_ordered_list() {
+        let mut doc = StructuredDocument::new();
+        for (idx, text) in ["First", "Second"].into_iter().enumerate() {
+            let mut block = Block::new(BlockType::ListItem {
+                ordered: true,
+                number: Some((idx + 1) as u64),
+                checkbox: None,
+            });
+            block
+                .content
+                .push(InlineContent::Text(TextRun::plain(text)));
+            doc.add_block(block);
+        }
+
+        let html = document_to_html(&doc);
+        assert!(html.contains("<ol>"), "html was: {html}");
+        assert!(html.contains("<li>"), "html was: {html}");
+        assert!(html.contains("First"), "html was: {html}");
+        assert!(html.contains("Second"), "html was: {html}");
     }
 
     #[test]

--- a/gui/src/richtext/structured_editor.rs
+++ b/gui/src/richtext/structured_editor.rs
@@ -3034,6 +3034,70 @@ impl StructuredEditor {
         String::new()
     }
 
+    /// Get the selected content as a [`StructuredDocument`], preserving block
+    /// types and inline styling. Returns `None` when there is no selection or
+    /// the selection is empty.
+    pub fn get_selection_document(&self) -> Option<StructuredDocument> {
+        let (start, end) = self.selection?;
+
+        // Ensure start <= end
+        let (start, end) = if start.block_index < end.block_index
+            || (start.block_index == end.block_index && start.offset <= end.offset)
+        {
+            (start, end)
+        } else {
+            (end, start)
+        };
+
+        let blocks = self.document.blocks();
+        if start.block_index >= blocks.len() {
+            return None;
+        }
+
+        let mut doc = StructuredDocument::new();
+
+        if start.block_index == end.block_index {
+            let block = &blocks[start.block_index];
+            doc.add_block(Self::extract_block_range(block, start.offset, end.offset));
+        } else {
+            let last = end.block_index.min(blocks.len() - 1);
+            for (idx, block) in blocks
+                .iter()
+                .enumerate()
+                .take(last + 1)
+                .skip(start.block_index)
+            {
+                let extracted = if idx == start.block_index {
+                    Self::extract_block_range(block, start.offset, block.text_len())
+                } else if idx == last {
+                    Self::extract_block_range(block, 0, end.offset)
+                } else {
+                    block.clone()
+                };
+                doc.add_block(extracted);
+            }
+        }
+
+        if doc.blocks().iter().all(Block::is_empty) {
+            None
+        } else {
+            Some(doc)
+        }
+    }
+
+    /// Extract the inline content within `[start, end)` (flattened byte
+    /// offsets) of `block`, preserving its block type and inline styling.
+    fn extract_block_range(block: &Block, start: usize, end: usize) -> Block {
+        let mut head = block.clone();
+        // head keeps [0, start); `tail` holds [start, len).
+        let tail = head.split_content_at(start);
+        let mut result = Block::new(block.block_type.clone());
+        result.content = tail;
+        // Drop everything from (end - start) onwards, leaving [start, end).
+        let _ = result.split_content_at(end.saturating_sub(start));
+        result
+    }
+
     /// Cut the selected text (copy and delete)
     pub fn cut(&mut self) -> Result<String, EditError> {
         let text = self.get_selection_text();
@@ -3175,6 +3239,67 @@ mod tests {
         editor.insert_text("Hello").unwrap();
         assert_eq!(editor.document().to_plain_text(), "Hello");
         assert_eq!(editor.cursor().offset, 5);
+    }
+
+    #[test]
+    fn selection_document_preserves_block_types_and_styles() {
+        let mut editor = StructuredEditor::new();
+        {
+            let doc = editor.document_mut();
+            *doc = StructuredDocument::new();
+
+            let mut heading = Block::heading(1);
+            heading
+                .content
+                .push(InlineContent::Text(TextRun::plain("Title")));
+            doc.add_block(heading);
+
+            let mut para = Block::paragraph();
+            para.content
+                .push(InlineContent::Text(TextRun::plain("Hello ")));
+            para.content.push(InlineContent::Text(TextRun::new(
+                "world",
+                TextStyle::bold(),
+            )));
+            doc.add_block(para);
+        }
+
+        // Select from after "Ti" in the heading through "Hello wo" in the
+        // paragraph (spanning two blocks and ending inside the bold run).
+        editor.set_selection(DocumentPosition::new(0, 2), DocumentPosition::new(1, 8));
+
+        let sel = editor
+            .get_selection_document()
+            .expect("selection should produce a document");
+        assert_eq!(sel.block_count(), 2);
+
+        // First block keeps the heading type and only the selected tail.
+        assert!(matches!(
+            sel.blocks()[0].block_type,
+            BlockType::Heading { level: 1 }
+        ));
+        assert_eq!(sel.blocks()[0].to_plain_text(), "tle");
+
+        // Second block keeps the paragraph type, the selected prefix, and the
+        // bold styling on the part of "world" that was inside the selection.
+        assert!(matches!(sel.blocks()[1].block_type, BlockType::Paragraph));
+        assert_eq!(sel.blocks()[1].to_plain_text(), "Hello wo");
+        let bold_text: String = sel.blocks()[1]
+            .content
+            .iter()
+            .filter_map(|c| match c {
+                InlineContent::Text(run) if run.style.bold => Some(run.text.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(bold_text, "wo");
+    }
+
+    #[test]
+    fn selection_document_none_without_selection() {
+        let mut editor = StructuredEditor::new();
+        editor.insert_text("Hello").unwrap();
+        assert!(editor.get_selection_document().is_none());
     }
 
     #[test]

--- a/gui/src/ui_adapters.rs
+++ b/gui/src/ui_adapters.rs
@@ -21,24 +21,33 @@ impl StructuredRichUI {
         self.0.display.borrow().editor().selection().is_some()
     }
 
-    pub fn cut_selection(&mut self) -> Option<String> {
-        let result = {
-            let mut disp = self.0.display.borrow_mut();
-            disp.editor_mut().cut()
+    /// Cut the current selection to the system clipboard (HTML + Markdown).
+    /// Returns `true` if there was a selection that was cut.
+    pub fn cut_selection(&mut self) -> bool {
+        let doc = self.0.display.borrow().editor().get_selection_document();
+        let Some(doc) = doc else {
+            return false;
         };
-        match result {
-            Ok(text) => {
-                self.0.notify_change();
-                if text.is_empty() { None } else { Some(text) }
-            }
-            Err(_) => None,
+        crate::clipboard::copy_structured_to_system(&doc);
+        {
+            let mut disp = self.0.display.borrow_mut();
+            let _ = disp.editor_mut().delete_selection();
         }
+        self.0.notify_change();
+        true
     }
 
-    pub fn copy_selection(&self) -> Option<String> {
-        let disp = self.0.display.borrow();
-        let text = disp.editor().copy();
-        if text.is_empty() { None } else { Some(text) }
+    /// Copy the current selection to the system clipboard (HTML + Markdown).
+    /// Returns `true` if there was a selection that was copied.
+    pub fn copy_selection(&self) -> bool {
+        let doc = self.0.display.borrow().editor().get_selection_document();
+        match doc {
+            Some(doc) => {
+                crate::clipboard::copy_structured_to_system(&doc);
+                true
+            }
+            None => false,
+        }
     }
 
     pub fn paste_from_clipboard(&mut self) {


### PR DESCRIPTION
Copy now places both HTML and Markdown on the clipboard in a single atomic operation, using arboard's `set().html(html, Some(markdown))`: HTML as the `text/html` flavor for rich-text targets, with Markdown as the `text/plain` alternative for plain-text and Markdown-aware targets. A real text/markdown MIME atom isn't possible—arboard only exposes `text` + `html(+alt)` + `image`.