### PR TITLE
gui: Always trigger save when leaving current page

### DIFF
--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -82,6 +82,40 @@ impl AppState {
         }
     }
 }
+/// Flush any pending changes of the currently open page to disk immediately.
+///
+/// This is the "save when walking away" safeguard: it runs before navigating to
+/// another page (links, history, page picker, new page) and when the window is
+/// closing, so edits are never lost to the debounced autosave timer. Saving is a
+/// no-op when the content is unchanged or the page is a read-only plugin page
+/// (handled inside `AutoSaveState::trigger_save`).
+fn save_current_page(
+    app_state: &Rc<RefCell<AppState>>,
+    autosave_state: &Rc<RefCell<AutoSaveState>>,
+    active_editor: &Rc<RefCell<Rc<RefCell<dyn PageUI>>>>,
+    statusbar: &Rc<RefCell<StatusBar>>,
+) {
+    if let (Ok(ed_ptr), Ok(mut as_state), Ok(app_st)) = (
+        active_editor.try_borrow(),
+        autosave_state.try_borrow_mut(),
+        app_state.try_borrow(),
+    ) {
+        let ed_ref = (*ed_ptr).borrow();
+        match as_state.trigger_save(&*ed_ref, &app_st.store) {
+            Ok(()) => {
+                if let Ok(mut sb) = statusbar.try_borrow_mut() {
+                    sb.set_status(&as_state.get_status_text());
+                }
+            }
+            Err(e) => {
+                if let Ok(mut sb) = statusbar.try_borrow_mut() {
+                    sb.set_status(&format!("Error: {}", e));
+                }
+            }
+        }
+    }
+}
+
 fn load_page_helper(
     page_name: &str,
     app_state: &Rc<RefCell<AppState>>,
@@ -90,6 +124,10 @@ fn load_page_helper(
     statusbar: &Rc<RefCell<StatusBar>>,
     restore_scroll: Option<i32>,
 ) {
+    // Save the page we're leaving before its content is replaced below, so
+    // switching pages (or creating a new one) never drops unsaved edits.
+    save_current_page(app_state, autosave_state, active_editor, statusbar);
+
     // If we're not restoring from history, update the scroll position of the current history entry
     if restore_scroll.is_none() {
         let scroll_pos = active_editor.borrow().borrow().scroll_pos();
@@ -538,6 +576,8 @@ fn main() {
         let search_bar_for_resize = search_bar.clone();
         let active_editor_for_resize = active_editor.clone();
         let statusbar_for_resize = statusbar.clone();
+        let app_state_for_close = app_state.clone();
+        let autosave_for_close = autosave_state.clone();
 
         wind.handle(move |win, event| match event {
             enums::Event::Move | enums::Event::Resize => {
@@ -628,6 +668,13 @@ fn main() {
                 false
             }
             enums::Event::Close => {
+                // Flush the open note before the window goes away.
+                save_current_page(
+                    &app_state_for_close,
+                    &autosave_for_close,
+                    &active_editor_for_resize,
+                    &statusbar_for_resize,
+                );
                 if let Some(handle) = {
                     let mut slot = pending.borrow_mut();
                     slot.take()

--- a/gui/src/menu.rs
+++ b/gui/src/menu.rs
@@ -3,6 +3,10 @@ use super::{
     navigate_forward, page_picker, search_bar::SearchBar, statusbar::StatusBar,
     window_state::WindowGeometry, wire_editor_callbacks,
 };
+// Only the non-macOS in-app Quit item saves explicitly; on macOS the system
+// Quit routes through the window Close event, which already saves.
+#[cfg(not(target_os = "macos"))]
+use super::save_current_page;
 use fltk::{
     app, button,
     enums::{self, Key, Shortcut},
@@ -332,9 +336,22 @@ fn populate_menu<M>(
     }
 
     #[cfg(not(target_os = "macos"))]
-    menu_bar.add("Page/Quit", quit_shortcut, menu::MenuFlag::Normal, |_| {
-        app::quit();
-    });
+    {
+        let app_state = app_state.clone();
+        let autosave_state = autosave_state.clone();
+        let active_editor = active_editor.clone();
+        let statusbar = statusbar.clone();
+        menu_bar.add(
+            "Page/Quit",
+            quit_shortcut,
+            menu::MenuFlag::Normal,
+            move |_| {
+                // Save the open note before leaving.
+                save_current_page(&app_state, &autosave_state, &active_editor, &statusbar);
+                app::quit();
+            },
+        );
+    }
 
     // Edit menu
     {


### PR DESCRIPTION
Always trigger save when:
- opening a different page (link/picker/menu)
- back / forward
- creating a new page
- closing window & quitting the app