### PR TITLE
Rework note picker, show timestamps & preview, remember scroll positions, allow quick switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ While pre-1.0, the minor version is bumped for breaking changes.
 
 ### Added
 
+- Returning to a recently visited note now resumes at the scroll position you
+  left it at, rather than jumping to the top — for the last 10 notes, and via any
+  navigation (links, the picker, back/forward). This memory is in-memory only and
+  is not persisted across restarts.
 - The note picker now remembers when each note was last opened and persists this
   per wiki (in the application data directory, keyed by a hash of the wiki's
   path). The recency ordering therefore survives restarts, and separate wikis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,26 @@ While pre-1.0, the minor version is bumped for breaking changes.
 
 ## [Unreleased]
 
+### Added
+
+- The note picker now remembers when each note was last opened and persists this
+  per wiki (in the application data directory, keyed by a hash of the wiki's
+  path). The recency ordering therefore survives restarts, and separate wikis
+  opened with `--directory` keep independent histories.
+
 ### Changed
 
+- The note picker has been reworked and now opens with `Cmd-O`/`Ctrl-O`
+  (previously "Go to Page" on `Cmd-P`/`Ctrl-P`). With an empty query it lists
+  notes by last-opened date; every row shows a one-line plaintext preview of the
+  note's first paragraphs (Markdown stripped, ellipsized to fit) alongside its
+  last-modification time. Keyboard interaction mirrors VS Code's quick-open: type
+  to filter, move with the arrow keys, or keep the modifier held after opening
+  and tap `O` again to step the selection down (`Shift` to go up) — releasing the
+  modifier opens the highlighted note. The currently open note starts selected.
+- User-facing wording now says "note" instead of "page": the _Page_ menu is now
+  _Note_ (with _New Note …_ and _Open Note …_), and the new-note dialog and the
+  status bar ("Note: …") follow suit.
 - The text rendering and editing engine has been carved out of Piki into a new
   shared crate, `rutle` (`rutle = "0.2.0"` on crates.io), and the `gui` crate
   now builds on it instead of its own homegrown implementation. This removes

--- a/README.md
+++ b/README.md
@@ -175,12 +175,12 @@ piki-gui -d /path/to/wiki
 | Shortcut              | Action            |
 | --------------------- | ----------------- |
 | **Navigation**        |                   |
-| `Cmd+N`               | New page          |
-| `Cmd+P`               | Open page picker  |
+| `Cmd+N`               | New note          |
+| `Cmd+O`               | Open note picker  |
 | `Cmd+[`               | Back              |
 | `Cmd+]`               | Forward           |
 | `Cmd+Option+F`        | Jump to frontpage |
-| `Cmd+Option+I`        | Open page index   |
+| `Cmd+Option+I`        | Open note index   |
 | **Editing**           |                   |
 | `Cmd+Z`               | Undo              |
 | `Cmd+Shift+Z`         | Redo              |

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -6,6 +6,7 @@ mod link_handler;
 mod markdown_editor;
 mod menu;
 mod page_picker;
+mod recency;
 pub mod responsive_scrollbar;
 mod search_bar;
 mod statusbar;
@@ -18,6 +19,7 @@ use history::History;
 use piki_core::{DocumentStore, IndexPlugin, PluginRegistry, TodoPlugin};
 use piki_gui::page_ui::PageUI;
 use piki_gui::ui_adapters::StructuredRichUI;
+use recency::RecentPages;
 use search_bar::SearchBar;
 use statusbar::StatusBar;
 use std::cell::RefCell;
@@ -51,15 +53,41 @@ struct AppState {
     plugin_registry: PluginRegistry,
     current_page: String,
     history: History,
+    /// When each page was last opened, used by the page picker to order notes
+    /// and to resolve the "previous note" for a double Cmd-O/Ctrl-O.
+    recent_pages: RecentPages,
+    /// Where `recent_pages` is persisted (None if no data dir is available).
+    recent_pages_path: Option<PathBuf>,
 }
 
 impl AppState {
-    fn new(store: DocumentStore, plugin_registry: PluginRegistry, initial_page: String) -> Self {
+    fn new(
+        store: DocumentStore,
+        plugin_registry: PluginRegistry,
+        initial_page: String,
+        recent_pages_path: Option<PathBuf>,
+    ) -> Self {
+        let recent_pages = recent_pages_path
+            .as_deref()
+            .map(RecentPages::load)
+            .unwrap_or_default();
         AppState {
             store,
             plugin_registry,
             current_page: initial_page,
             history: History::new(),
+            recent_pages,
+            recent_pages_path,
+        }
+    }
+
+    /// Record that `page` was just opened and persist the updated recency store.
+    fn mark_page_opened(&mut self, page: &str) {
+        self.recent_pages.mark_opened(page);
+        if let Some(path) = &self.recent_pages_path
+            && let Err(e) = self.recent_pages.save(path)
+        {
+            eprintln!("Failed to save recent pages: {e}");
         }
     }
 
@@ -189,6 +217,13 @@ fn load_page_helper(
                     .push(page_name.to_string(), final_scroll_pos);
             }
 
+            // Record the open so the page picker can order notes by recency and
+            // resolve the "previous note" for a double Cmd-O. Plugin pages (e.g.
+            // !index) are generated views that never appear in the picker list.
+            if !is_plugin {
+                app_state.borrow_mut().mark_page_opened(page_name);
+            }
+
             // Reset autosave state for the new page
             if let Ok(mut as_state) = autosave_state.try_borrow_mut() {
                 as_state.reset_for_page(page_name, &content);
@@ -203,9 +238,9 @@ fn load_page_helper(
             let page_text = if let Some(plugin_name) = page_name.strip_prefix('!') {
                 format!("Plugin: {}", plugin_name)
             } else if content.is_empty() {
-                format!("Page: {} (new)", page_name)
+                format!("Note: {} (new)", page_name)
             } else {
-                format!("Page: {}", page_name)
+                format!("Note: {}", page_name)
             };
 
             statusbar.borrow_mut().set_page(&page_text);
@@ -363,10 +398,13 @@ fn main() {
     plugin_registry.register("index", Box::new(IndexPlugin));
     plugin_registry.register("todo", Box::new(TodoPlugin));
 
+    let recent_pages_path = window_state::recent_pages_file(&directory);
+
     let app_state = Rc::new(RefCell::new(AppState::new(
         store,
         plugin_registry,
         args.page.clone(),
+        recent_pages_path,
     )));
     let autosave_state = Rc::new(RefCell::new(AutoSaveState::new()));
 

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -8,6 +8,7 @@ mod menu;
 mod page_picker;
 mod recency;
 pub mod responsive_scrollbar;
+mod scroll_memory;
 mod search_bar;
 mod statusbar;
 mod window_state;
@@ -20,6 +21,7 @@ use piki_core::{DocumentStore, IndexPlugin, PluginRegistry, TodoPlugin};
 use piki_gui::page_ui::PageUI;
 use piki_gui::ui_adapters::StructuredRichUI;
 use recency::RecentPages;
+use scroll_memory::ScrollMemory;
 use search_bar::SearchBar;
 use statusbar::StatusBar;
 use std::cell::RefCell;
@@ -58,6 +60,9 @@ struct AppState {
     recent_pages: RecentPages,
     /// Where `recent_pages` is persisted (None if no data dir is available).
     recent_pages_path: Option<PathBuf>,
+    /// In-memory scroll positions for recently visited notes, so returning to a
+    /// note resumes where the user left off.
+    scroll_positions: ScrollMemory,
 }
 
 impl AppState {
@@ -78,6 +83,7 @@ impl AppState {
             history: History::new(),
             recent_pages,
             recent_pages_path,
+            scroll_positions: ScrollMemory::new(),
         }
     }
 
@@ -155,13 +161,20 @@ fn load_page_helper(
     // switching pages (or creating a new one) never drops unsaved edits.
     save_current_page(app_state, autosave_state, active_editor, statusbar);
 
-    // If we're not restoring from history, update the scroll position of the current history entry
-    if restore_scroll.is_none() {
-        let scroll_pos = active_editor.borrow().borrow().scroll_pos();
-        app_state
-            .borrow_mut()
-            .history
-            .update_scroll_position(scroll_pos);
+    // Record the scroll position of the note we're leaving: into the current
+    // back/forward history entry (only for non-history navigation), and always
+    // into the recent-notes scroll memory so returning to it later — via a link
+    // or the picker — resumes where we were.
+    {
+        let leaving_scroll = active_editor.borrow().borrow().scroll_pos();
+        let mut state = app_state.borrow_mut();
+        if restore_scroll.is_none() {
+            state.history.update_scroll_position(leaving_scroll);
+        }
+        let leaving_page = state.current_page.clone();
+        state
+            .scroll_positions
+            .remember(&leaving_page, leaving_scroll);
     }
 
     // Check if this is a plugin page
@@ -193,19 +206,18 @@ fn load_page_helper(
                 editor_mut.set_readonly(is_plugin);
             }
 
-            // Restore scroll position if provided (from history navigation)
-            // Otherwise, scroll to top for normal navigation
-            let final_scroll_pos = if let Some(scroll_pos) = restore_scroll {
+            // Decide where to scroll: an explicit position from back/forward
+            // history wins; otherwise resume the remembered position for this
+            // note (if it is still one of the recent ones), falling back to top.
+            let target_scroll = restore_scroll
+                .or_else(|| app_state.borrow().scroll_positions.get(page_name))
+                .unwrap_or(0);
+            {
                 let active = active_editor.borrow();
                 let mut ed = (*active).borrow_mut();
-                ed.set_scroll_pos(scroll_pos);
-                scroll_pos
-            } else {
-                let active = active_editor.borrow();
-                let mut ed = (*active).borrow_mut();
-                ed.set_scroll_pos(0);
-                0
-            };
+                ed.set_scroll_pos(target_scroll);
+            }
+            let final_scroll_pos = target_scroll;
 
             // Drop the editor borrow before manipulating history
 

--- a/gui/src/menu.rs
+++ b/gui/src/menu.rs
@@ -169,7 +169,7 @@ fn populate_menu<M>(
         Shortcut::Ctrl
     };
     let new_shortcut = cmd | 'n';
-    let gotopage_shortcut = cmd | 'p';
+    let gotopage_shortcut = cmd | 'o';
 
     let back_shortcut = if cfg!(target_os = "macos") {
         Shortcut::Command | '['
@@ -221,7 +221,7 @@ fn populate_menu<M>(
         let statusbar = statusbar.clone();
         let wind_ref = wind_ref.clone();
         menu_bar.add(
-            "Page/New Page …",
+            "Note/New Note …",
             new_shortcut,
             menu::MenuFlag::Normal,
             move |_| {
@@ -243,7 +243,7 @@ fn populate_menu<M>(
         let statusbar = statusbar.clone();
         let wind_ref = wind_ref.clone();
         menu_bar.add(
-            "Page/_Go to Page …",
+            "Note/_Open Note …",
             gotopage_shortcut,
             menu::MenuFlag::Normal,
             move |_| {
@@ -266,7 +266,7 @@ fn populate_menu<M>(
         let active_editor = active_editor.clone();
         let statusbar = statusbar.clone();
         menu_bar.add(
-            "Page/Back",
+            "Note/Back",
             back_shortcut,
             menu::MenuFlag::Normal,
             move |_| {
@@ -281,7 +281,7 @@ fn populate_menu<M>(
         let active_editor = active_editor.clone();
         let statusbar = statusbar.clone();
         menu_bar.add(
-            "Page/_Forward",
+            "Note/_Forward",
             forward_shortcut,
             menu::MenuFlag::Normal,
             move |_| {
@@ -296,7 +296,7 @@ fn populate_menu<M>(
         let active_editor = active_editor.clone();
         let statusbar = statusbar.clone();
         menu_bar.add(
-            "Page/Go to Frontpage",
+            "Note/Go to Frontpage",
             frontpage_shortcut,
             menu::MenuFlag::Normal,
             move |_| {
@@ -314,11 +314,11 @@ fn populate_menu<M>(
 
     {
         #[cfg(not(target_os = "macos"))]
-        let label = "Page/_Go to Index";
+        let label = "Note/_Go to Index";
         // No separator on macOS for this item,
         // as there's not going to be a Quit item below it.
         #[cfg(target_os = "macos")]
-        let label = "Page/Go to Index";
+        let label = "Note/Go to Index";
         let app_state = app_state.clone();
         let autosave_state = autosave_state.clone();
         let active_editor = active_editor.clone();
@@ -342,7 +342,7 @@ fn populate_menu<M>(
         let active_editor = active_editor.clone();
         let statusbar = statusbar.clone();
         menu_bar.add(
-            "Page/Quit",
+            "Note/Quit",
             quit_shortcut,
             menu::MenuFlag::Normal,
             move |_| {
@@ -1377,11 +1377,11 @@ fn show_new_page_dialog(
     let pos_x = px + (pw - width) / 2;
     let pos_y = py + (ph - height) / 2;
 
-    let mut win = window::Window::new(pos_x.max(0), pos_y.max(0), width, height, Some("New Page"));
+    let mut win = window::Window::new(pos_x.max(0), pos_y.max(0), width, height, Some("New Note"));
     win.make_modal(true);
     win.begin();
 
-    let mut label = frame::Frame::new(10, 10, width - 20, 24, Some("Enter new page name:"));
+    let mut label = frame::Frame::new(10, 10, width - 20, 24, Some("Enter new note name:"));
     label.set_align(enums::Align::Inside | enums::Align::Left);
 
     let mut input = input::Input::new(10, 40, width - 20, 28, None);

--- a/gui/src/page_picker.rs
+++ b/gui/src/page_picker.rs
@@ -1,7 +1,8 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
+use std::time::SystemTime;
 
-use fltk::{self, prelude::*, window};
+use fltk::{self, draw, enums::Font, prelude::*, window};
 use piki_gui::page_ui::PageUI;
 
 use crate::autosave::AutoSaveState;
@@ -9,10 +10,14 @@ use crate::autosave::AutoSaveState;
 thread_local! {
     /// Guards against more than one picker being open at a time. Repeatedly
     /// triggering the shortcut would otherwise stack pickers, because on macOS
-    /// the native system menu fires the Cmd-P key equivalent before FLTK's
+    /// the native system menu fires the Cmd-O key equivalent before FLTK's
     /// modal window can intercept it.
     static PICKER_OPEN: Cell<bool> = const { Cell::new(false) };
 }
+
+/// Text size (points) used for the browser rows. Kept in sync with the font we
+/// measure against so ellipsis truncation lines up with what FLTK draws.
+const ROW_TEXT_SIZE: i32 = 14;
 
 /// The application menu saved while the picker is open, so it can be restored
 /// verbatim on close. On macOS this is the previous `NSMenu`; elsewhere nothing
@@ -25,7 +30,7 @@ type SavedAppMenu = ();
 /// Hide the application's menu bar so its keyboard shortcuts cannot fire while
 /// the modal picker is open, returning the previous menu so it can be restored
 /// untouched. Marking the FLTK window modal is not enough on macOS: the native
-/// system menu dispatches key equivalents (e.g. Cmd-P) before FLTK's modal grab
+/// system menu dispatches key equivalents (e.g. Cmd-O) before FLTK's modal grab
 /// can swallow them, which is what lets pickers stack today.
 #[cfg(target_os = "macos")]
 fn suspend_app_menu() -> SavedAppMenu {
@@ -57,7 +62,239 @@ fn suspend_app_menu() -> SavedAppMenu {}
 #[cfg(not(target_os = "macos"))]
 fn restore_app_menu(_saved: &SavedAppMenu) {}
 
-/// Modal quick page picker with fuzzy filtering and keyboard navigation.
+/// A shared, mutable callback taking a single string slice — used both for the
+/// "filter by query" and "open note by name" actions.
+type StrCallback = Rc<RefCell<dyn FnMut(&str)>>;
+
+/// One entry in the picker list.
+struct Row {
+    /// Page name / path used to open the note.
+    name: String,
+    /// Short plaintext preview parsed from the first paragraphs of the note.
+    abbrev: String,
+    /// Preformatted last-modification timestamp (right-hand column).
+    date: String,
+    /// Last-opened time (ms since epoch), used to order notes by recency.
+    last_open: Option<i64>,
+    /// Last-modification time (ms since epoch), used as a secondary sort key.
+    modified: Option<i64>,
+}
+
+/// Parse the first few paragraphs of a markdown note into a one-line plaintext
+/// preview: markdown syntax is stripped and whitespace collapsed. The result is
+/// capped at `max_chars`; the picker adds an ellipsis when it still overflows
+/// the available column width.
+fn abbreviate(markdown: &str, max_chars: usize) -> String {
+    use pulldown_cmark::{Event, Options, Parser};
+
+    let mut out = String::new();
+    for event in Parser::new_ext(markdown, Options::empty()) {
+        match event {
+            Event::Text(t) | Event::Code(t) => out.push_str(&t),
+            Event::SoftBreak | Event::HardBreak => out.push(' '),
+            // A closing tag ends a block/inline run; keep words from adjacent
+            // blocks (e.g. a heading and the paragraph below it) separated.
+            Event::End(_) => out.push(' '),
+            _ => {}
+        }
+        // Stop once we clearly have more than enough text for a preview.
+        if out.len() >= max_chars * 4 {
+            break;
+        }
+    }
+
+    let collapsed = out.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() > max_chars {
+        collapsed.chars().take(max_chars).collect()
+    } else {
+        collapsed
+    }
+}
+
+/// Format a modification time the way the mockup shows it: "Today 1:08 PM",
+/// "Yesterday 9:30 AM", "Jul 3" within the current year, else "2026-07-03".
+fn format_timestamp(time: SystemTime) -> String {
+    use chrono::{DateTime, Datelike, Local};
+
+    let dt: DateTime<Local> = time.into();
+    let now = Local::now();
+    let day = dt.date_naive();
+    let today = now.date_naive();
+
+    if day == today {
+        dt.format("Today %-I:%M %p").to_string()
+    } else if Some(day) == today.pred_opt() {
+        dt.format("Yesterday %-I:%M %p").to_string()
+    } else if dt.year() == now.year() {
+        dt.format("%b %-d").to_string()
+    } else {
+        dt.format("%Y-%m-%d").to_string()
+    }
+}
+
+fn millis_since_epoch(time: SystemTime) -> Option<i64> {
+    time.duration_since(SystemTime::UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_millis() as i64)
+}
+
+/// Width in pixels of `s` in the browser's font. Callers must have set the
+/// measuring font via [`draw::set_font`] first.
+fn text_width(s: &str) -> f64 {
+    draw::width(s)
+}
+
+/// `@` starts a format code in FLTK browsers, and `\t` separates columns.
+/// Double any `@` so page names / previews containing it (e.g. email
+/// addresses) render literally, and drop stray tabs.
+fn escape(s: &str) -> String {
+    s.replace('@', "@@").replace('\t', " ")
+}
+
+/// Truncate `text` so it fits within `avail` pixels, appending an ellipsis when
+/// anything is dropped. Assumes the measuring font is already set.
+fn truncate_to_width(text: &str, avail: f64) -> String {
+    if text_width(text) <= avail {
+        return text.to_string();
+    }
+    let ellipsis = "…";
+    let target = (avail - text_width(ellipsis)).max(0.0);
+    let mut acc = String::new();
+    let mut used = 0.0;
+    let mut buf = [0u8; 4];
+    for ch in text.chars() {
+        let cw = text_width(ch.encode_utf8(&mut buf));
+        if used + cw > target {
+            break;
+        }
+        acc.push(ch);
+        used += cw;
+    }
+    format!("{}{ellipsis}", acc.trim_end())
+}
+
+/// The left column text: "name — preview", with the preview ellipsized to fit
+/// `avail` pixels while the name is kept intact whenever possible.
+fn left_column(row: &Row, avail: f64) -> String {
+    if row.abbrev.is_empty() {
+        return truncate_to_width(&row.name, avail);
+    }
+    let prefix = format!("{} — ", row.name);
+    let prefix_w = text_width(&prefix);
+    if prefix_w + text_width(&row.abbrev) <= avail {
+        format!("{prefix}{}", row.abbrev)
+    } else if prefix_w >= avail {
+        // Even the name barely fits; truncate it and drop the preview.
+        truncate_to_width(&row.name, avail)
+    } else {
+        let preview = truncate_to_width(&row.abbrev, avail - prefix_w);
+        format!("{prefix}{preview}")
+    }
+}
+
+/// Build the full browser line (both columns) for a row. The measuring font
+/// must already be set.
+fn browser_line(row: &Row, left_avail: f64) -> String {
+    let left = escape(&left_column(row, left_avail));
+    if row.date.is_empty() {
+        left
+    } else {
+        // Second column, right-aligned (`@r`), holding the timestamp.
+        format!("{left}\t@r{}", escape(&row.date))
+    }
+}
+
+/// Order all rows most-recently-opened first (never-opened notes sink to the
+/// bottom, ordered by last modification), used when the query box is empty.
+fn recency_order(rows: &[Row]) -> Vec<usize> {
+    let mut order: Vec<usize> = (0..rows.len()).collect();
+    order.sort_by(|&a, &b| {
+        let ra = &rows[a];
+        let rb = &rows[b];
+        rb.last_open
+            .cmp(&ra.last_open)
+            .then(rb.modified.cmp(&ra.modified))
+            .then_with(|| ra.name.to_lowercase().cmp(&rb.name.to_lowercase()))
+    });
+    order
+}
+
+// Simple fuzzy match: subsequence match with light scoring.
+fn fuzzy_score(query: &str, candidate: &str) -> Option<i32> {
+    if query.is_empty() {
+        return Some(0);
+    }
+    let mut score = 0i32;
+    let mut qi = 0usize;
+    let q = query.to_lowercase();
+    let c = candidate.to_lowercase();
+    let qb = q.as_bytes();
+    let cb = c.as_bytes();
+    for (i, &ch) in cb.iter().enumerate() {
+        if qi < qb.len() && ch == qb[qi] {
+            // Reward matches earlier and consecutive
+            score += 10 - ((i as i32).min(9));
+            // Bonus for start of word or after '/'
+            if i == 0 || cb.get(i - 1) == Some(&b'/') {
+                score += 5;
+            }
+            qi += 1;
+            if qi == qb.len() {
+                break;
+            }
+        }
+    }
+    if qi == qb.len() {
+        // Prefer prefix and exact
+        if c.starts_with(&q) {
+            score += 20;
+        }
+        if c == q {
+            score += 50;
+        }
+        Some(score)
+    } else {
+        None
+    }
+}
+
+/// Next 1-based selection when stepping the quick-open cycle with the modifier
+/// held. `cur` and `sz` are 1-based; the selection wraps around both ends.
+/// Returns 0 for an empty list.
+fn cycle_index(cur: i32, sz: i32, up: bool) -> i32 {
+    if sz <= 0 {
+        return 0;
+    }
+    let cur = cur.clamp(1, sz);
+    if up {
+        if cur <= 1 { sz } else { cur - 1 }
+    } else if cur >= sz {
+        1
+    } else {
+        cur + 1
+    }
+}
+
+/// Order rows matching `query` by fuzzy score (best first), dropping non-matches.
+fn fuzzy_order(rows: &[Row], query: &str) -> Vec<usize> {
+    let mut scored: Vec<(i32, usize)> = rows
+        .iter()
+        .enumerate()
+        .filter_map(|(i, r)| fuzzy_score(query, &r.name).map(|s| (s, i)))
+        .collect();
+    scored.sort_by(|a, b| {
+        b.0.cmp(&a.0).then_with(|| {
+            rows[a.1]
+                .name
+                .to_lowercase()
+                .cmp(&rows[b.1].name.to_lowercase())
+        })
+    });
+    scored.into_iter().map(|(_, i)| i).collect()
+}
+
+/// Modal "Open Note" picker: fuzzy filtering, recency ordering, previews and
+/// last-modified timestamps, with keyboard navigation.
 pub fn show_page_picker(
     app_state: Rc<RefCell<super::AppState>>,
     autosave_state: Rc<RefCell<AutoSaveState>>,
@@ -67,7 +304,7 @@ pub fn show_page_picker(
 ) {
     use fltk::{
         browser::HoldBrowser,
-        enums::{CallbackTrigger, Event, Key},
+        enums::{CallbackTrigger, Event, Key, Shortcut},
         input::Input,
         window::Window,
     };
@@ -78,29 +315,71 @@ pub fn show_page_picker(
         return;
     }
 
-    // Collect all pages once
-    let all_pages: Vec<String> = app_state
-        .borrow()
-        .store
-        .list_all_documents()
-        .unwrap_or_else(|_| vec![]);
+    // Gather every note plus the metadata the list shows. We read each file once
+    // here for its content (preview) and modification time; personal wikis are
+    // small enough that this is cheap.
+    let (rows, current_page) = {
+        let state = app_state.borrow();
+        let names = state.store.list_all_documents().unwrap_or_default();
+        let current = state.current_page.clone();
+        let rows: Vec<Row> = names
+            .into_iter()
+            .map(|name| {
+                let doc = state.store.load(&name).ok();
+                let content = doc.as_ref().map(|d| d.content.clone()).unwrap_or_default();
+                let mtime = doc.as_ref().and_then(|d| d.modified_time);
+                Row {
+                    abbrev: abbreviate(&content, 200),
+                    date: mtime.map(format_timestamp).unwrap_or_default(),
+                    last_open: state.recent_pages.last_opened(&name),
+                    modified: mtime.and_then(millis_since_epoch),
+                    name,
+                }
+            })
+            .collect();
+        (rows, current)
+    };
+    let rows = Rc::new(rows);
 
     // Create a modal dialog centered on parent
-    let width = 520;
-    let height = 420;
+    let width = 600;
+    let height = 460;
     let px = parent.x() + (parent.w() - width) / 2;
     let py = parent.y() + (parent.h() - height) / 2;
-    let mut win = Window::new(px.max(0), py.max(0), width, height, Some("Open Page"));
+    let mut win = Window::new(px.max(0), py.max(0), width, height, Some("Open Note"));
     win.begin();
     win.make_modal(true);
 
     let mut input = Input::new(10, 10, width - 20, 28, None);
     let mut list = HoldBrowser::new(10, 50, width - 20, height - 60, None);
     list.set_scrollbar_size(12);
+    list.set_text_size(ROW_TEXT_SIZE);
+
+    // Measure with the same font the browser draws in (default FLTK sans at our
+    // row size) so ellipsis truncation matches on screen.
+    draw::set_font(Font::Helvetica, ROW_TEXT_SIZE);
+
+    // Split the row into a flexible left column (name + preview) and a fixed
+    // right column just wide enough for the widest timestamp. FLTK only applies
+    // colour/alignment codes at the start of a column, so the right-aligned date
+    // has to live in its own column.
+    let date_w = rows
+        .iter()
+        .map(|r| text_width(&r.date))
+        .fold(0.0_f64, f64::max)
+        + 28.0;
+    // Conservative estimate of the drawable width (widget minus box + scrollbar)
+    // so the date column never collides with the scrollbar.
+    let inner = (width - 44) as f64;
+    let left_w = (inner - date_w).max(140.0);
+    list.set_column_char('\t');
+    list.set_column_widths(&[left_w as i32]);
+    // FLTK insets each field by a few pixels when drawing (see item_draw).
+    let left_avail = left_w - 8.0;
 
     // Disable the application menu (and therefore its keyboard shortcuts) for as
     // long as the picker is open, so it behaves like a real modal: app shortcuts
-    // such as Cmd-P no longer reach the window underneath. The menu is restored
+    // such as Cmd-O no longer reach the window underneath. The menu is restored
     // verbatim when the picker closes.
     // On non-macOS `suspend_app_menu()` returns `()`; wrapping a unit value is
     // intentional here so the type is uniform across platforms.
@@ -122,124 +401,79 @@ pub fn show_page_picker(
         }))
     };
 
-    // Helper: populate list with provided items and maintain selection
-    let mut populate_list = {
+    // Page names in current display order, parallel to the browser lines. The
+    // browser text is formatted (columns + preview), so accepting a selection
+    // maps the 1-based line back to a name through this list.
+    let results: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+
+    // Rebuild the list for a query: recency order when empty, fuzzy otherwise.
+    // With an empty query we pre-select the *current* note (the top of the
+    // recency list), so a held Cmd-O can then step the selection downwards.
+    let refill: StrCallback = {
         let mut list = list.clone();
-        move |items: &Vec<String>, selected_index: Option<usize>| {
+        let rows = rows.clone();
+        let results = results.clone();
+        let current_page = current_page.clone();
+        Rc::new(RefCell::new(move |query: &str| {
+            draw::set_font(Font::Helvetica, ROW_TEXT_SIZE);
+            let q = query.trim();
+            let order = if q.is_empty() {
+                recency_order(&rows)
+            } else {
+                fuzzy_order(&rows, q)
+            };
+
             list.clear();
-            for s in items {
-                list.add(s);
+            let mut names = Vec::with_capacity(order.len());
+            for &i in &order {
+                list.add(&browser_line(&rows[i], left_avail));
+                names.push(rows[i].name.clone());
             }
-            if let Some(idx) = selected_index {
-                if !items.is_empty() {
-                    let i = (idx.min(items.len() - 1) + 1) as i32; // 1-based
-                    list.select(i);
-                    list.top_line(i);
-                }
-            } else if !items.is_empty() {
-                list.select(1);
+
+            if !names.is_empty() {
+                let target = if q.is_empty() {
+                    Some(current_page.as_str())
+                } else {
+                    None
+                };
+                let line = target
+                    .and_then(|t| names.iter().position(|n| n == t))
+                    .map(|p| p as i32 + 1)
+                    .unwrap_or(1);
+                list.select(line);
                 list.top_line(1);
             }
-        }
+            *results.borrow_mut() = names;
+        }))
     };
 
-    // Simple fuzzy match: subsequence match with light scoring
-    fn fuzzy_score(query: &str, candidate: &str) -> Option<i32> {
-        if query.is_empty() {
-            return Some(0);
-        }
-        let mut score = 0i32;
-        let mut qi = 0usize;
-        let q = query.to_lowercase();
-        let c = candidate.to_lowercase();
-        let qb = q.as_bytes();
-        let cb = c.as_bytes();
-        for (i, &ch) in cb.iter().enumerate() {
-            if qi < qb.len() && ch == qb[qi] {
-                // Reward matches earlier and consecutive
-                score += 10 - ((i as i32).min(9));
-                // Bonus for start of word or after '/'
-                if i == 0 || cb.get(i - 1) == Some(&b'/') {
-                    score += 5;
-                }
-                qi += 1;
-                if qi == qb.len() {
-                    break;
-                }
-            }
-        }
-        if qi == qb.len() {
-            // Prefer prefix and exact
-            if c.starts_with(&q) {
-                score += 20;
-            }
-            if c == q {
-                score += 50;
-            }
-            Some(score)
-        } else {
-            None
-        }
-    }
+    // Initial population.
+    (refill.borrow_mut())("");
 
-    // Current filtered results and selection index (0-based)
-    let results: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(all_pages.clone()));
-    let selection: Rc<RefCell<usize>> = Rc::new(RefCell::new(0));
-
-    // Initial population
-    populate_list(&results.borrow(), Some(*selection.borrow()));
-
-    // Filtering callback when input changes
+    // Filter as the user types.
     {
-        let results = results.clone();
-        let mut list = list.clone();
+        let refill = refill.clone();
         input.set_trigger(CallbackTrigger::Changed);
         input.set_callback(move |inp| {
-            let q = inp.value();
-            let mut items: Vec<(i32, String)> = Vec::new();
-            if q.trim().is_empty() {
-                for s in &all_pages {
-                    items.push((0, s.clone()));
-                }
-            } else {
-                for s in &all_pages {
-                    if let Some(sc) = fuzzy_score(&q, s) {
-                        items.push((sc, s.clone()));
-                    }
-                }
-            }
-            // Sort by score desc then name asc
-            items.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
-            let filtered: Vec<String> = items.into_iter().map(|(_, s)| s).collect();
-            *results.borrow_mut() = filtered;
-            // Reset selection to top
-            list.clear();
-            for s in results.borrow().iter() {
-                list.add(s);
-            }
-            if list.size() > 0 {
-                list.select(1);
-                list.top_line(1);
-            }
+            (refill.borrow_mut())(&inp.value());
         });
     }
 
-    // Accept helper: open current selection and close dialog
+    // Accept helper: open the currently selected row. Closes the picker first
+    // (restoring the menu), then loads the note.
     let accept_cb: Rc<RefCell<dyn FnMut()>> = {
+        let list = list.clone();
+        let results = results.clone();
         let app_state = app_state.clone();
         let autosave_state = autosave_state.clone();
         let active_editor = active_editor.clone();
         let statusbar = statusbar.clone();
         let close_picker = close_picker.clone();
-        let list_for_accept = list.clone();
         Rc::new(RefCell::new(move || {
-            let idx = list_for_accept.value(); // 1-based
-            let name_opt = if idx > 0 {
-                list_for_accept.text(idx)
-            } else {
-                None
-            };
-            if let Some(name) = name_opt {
+            let idx = list.value(); // 1-based
+            if idx > 0
+                && let Some(name) = results.borrow().get((idx - 1) as usize).cloned()
+            {
                 (close_picker.borrow_mut())();
                 super::load_page_helper(
                     &name,
@@ -253,14 +487,41 @@ pub fn show_page_picker(
         }))
     };
 
-    // Keyboard handling on input: up/down/select/esc
+    // Keyboard handling on the input. Three interaction styles are supported,
+    // mirroring VS Code's quick-open:
+    //   1. type to filter, then Enter;
+    //   2. arrow keys to move the selection, then Enter;
+    //   3. keep the Cmd/Ctrl modifier held after opening and tap the hotkey (O)
+    //      again to step the selection downwards (Shift to go up); releasing the
+    //      modifier then opens the highlighted note.
+    // The app menu is suspended while the picker is open, so repeated Cmd-O
+    // presses arrive here as key events instead of re-firing the menu.
     {
         let mut list = list.clone();
         let accept_cb = accept_cb.clone();
         let close_picker = close_picker.clone();
+        // Set once the user taps the hotkey again while the modifier is held; a
+        // subsequent modifier release then commits the selection. Left false in
+        // the type/arrow flows so releasing the modifier does nothing there.
+        let mut navigating = false;
         input.handle(move |_, ev| match ev {
             Event::KeyDown => {
                 let key = fltk::app::event_key();
+                let state = fltk::app::event_state();
+
+                // Hotkey tapped again with the modifier still down: step the
+                // selection (down, or up with Shift) and arm commit-on-release.
+                if state.contains(Shortcut::Command) && key == Key::from_char('o') {
+                    let sz = list.size();
+                    if sz > 0 {
+                        let next = cycle_index(list.value(), sz, state.contains(Shortcut::Shift));
+                        list.select(next);
+                        list.make_visible(next);
+                        navigating = true;
+                    }
+                    return true;
+                }
+
                 match key {
                     Key::Down => {
                         let sz = list.size();
@@ -287,18 +548,36 @@ pub fn show_page_picker(
                         true
                     }
                     Key::Escape => {
-                        // Cancel
                         (close_picker.borrow_mut())();
                         true
                     }
                     _ => false,
                 }
             }
+            Event::KeyUp => {
+                // Commit when the held modifier is released after cycling. Detect
+                // either the modifier key's own release or the modifier bit
+                // having cleared from the event state.
+                if !navigating {
+                    return false;
+                }
+                let key = fltk::app::event_key();
+                #[cfg(target_os = "macos")]
+                let released_modifier = key == Key::MetaL || key == Key::MetaR;
+                #[cfg(not(target_os = "macos"))]
+                let released_modifier = key == Key::ControlL || key == Key::ControlR;
+                if released_modifier || !fltk::app::event_state().contains(Shortcut::Command) {
+                    navigating = false;
+                    (accept_cb.borrow_mut())();
+                    return true;
+                }
+                false
+            }
             _ => false,
         });
     }
 
-    // Double-click or Enter on list accepts
+    // Double-click or Enter on the list accepts; Escape cancels.
     {
         let accept_cb = accept_cb.clone();
         let close_picker = close_picker.clone();
@@ -316,7 +595,6 @@ pub fn show_page_picker(
                     (accept_cb.borrow_mut())();
                     true
                 } else if fltk::app::event_key() == Key::Escape {
-                    // Close on Esc
                     (close_picker.borrow_mut())();
                     true
                 } else {
@@ -338,4 +616,43 @@ pub fn show_page_picker(
     }
     win.show();
     let _ = input.take_focus();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cycle_down_steps_and_wraps() {
+        assert_eq!(cycle_index(1, 3, false), 2);
+        assert_eq!(cycle_index(2, 3, false), 3);
+        assert_eq!(cycle_index(3, 3, false), 1); // wrap to top
+    }
+
+    #[test]
+    fn cycle_up_steps_and_wraps() {
+        assert_eq!(cycle_index(3, 3, true), 2);
+        assert_eq!(cycle_index(2, 3, true), 1);
+        assert_eq!(cycle_index(1, 3, true), 3); // wrap to bottom
+    }
+
+    #[test]
+    fn cycle_handles_empty_and_unselected() {
+        assert_eq!(cycle_index(0, 0, false), 0);
+        // An unselected list (value 0) steps to the first item.
+        assert_eq!(cycle_index(0, 3, false), 2); // clamps to 1, then steps down
+        assert_eq!(cycle_index(0, 3, true), 3); // clamps to 1, then wraps up
+    }
+
+    #[test]
+    fn abbreviate_strips_markdown_and_collapses() {
+        let md = "# Title\n\nSome **bold** and `code` text.\n\n- item one\n- item two";
+        let out = abbreviate(md, 200);
+        assert_eq!(out, "Title Some bold and code text. item one item two");
+    }
+
+    #[test]
+    fn escape_doubles_at_signs_and_strips_tabs() {
+        assert_eq!(escape("a@b\tc"), "a@@b c");
+    }
 }

--- a/gui/src/recency.rs
+++ b/gui/src/recency.rs
@@ -1,0 +1,85 @@
+//! Tracks when each page was last opened.
+//!
+//! The page picker lists notes most-recently-opened first and lets a double
+//! `Cmd-O`/`Ctrl-O` jump straight back to the previous note. Both need to know
+//! *when* pages were last opened, which the in-session navigation [`History`]
+//! does not record. This is persisted as TOML next to the window-state file so
+//! the ordering survives restarts — otherwise "sort by last open date" would be
+//! empty on every launch. The file is scoped per wiki directory (see
+//! [`crate::window_state::recent_pages_file`]) so different wikis keep separate
+//! histories.
+//!
+//! [`History`]: crate::history::History
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RecentPages {
+    /// Page name -> last-opened time in milliseconds since the Unix epoch.
+    #[serde(default)]
+    opened: HashMap<String, i64>,
+}
+
+fn now_millis() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+impl RecentPages {
+    /// Load from `path`, returning an empty store if it is missing or corrupt.
+    pub fn load(path: &Path) -> Self {
+        fs::read_to_string(path)
+            .ok()
+            .and_then(|s| toml::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    /// Persist to `path`, creating parent directories as needed.
+    pub fn save(&self, path: &Path) -> io::Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let toml = toml::to_string_pretty(self)
+            .map_err(|e| io::Error::other(format!("toml serialization error: {e}")))?;
+        fs::write(path, toml)
+    }
+
+    /// Record that `page` was opened just now.
+    pub fn mark_opened(&mut self, page: &str) {
+        self.opened.insert(page.to_string(), now_millis());
+    }
+
+    /// The last-opened time (ms since epoch) for `page`, if it has been opened.
+    pub fn last_opened(&self, page: &str) -> Option<i64> {
+        self.opened.get(page).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mark_opened_then_last_opened_is_set() {
+        let mut r = RecentPages::default();
+        assert_eq!(r.last_opened("x"), None);
+        r.mark_opened("x");
+        assert!(r.last_opened("x").is_some());
+    }
+
+    #[test]
+    fn roundtrips_names_with_slashes() {
+        let mut r = RecentPages::default();
+        r.opened.insert("project-a/standup".into(), 42);
+        let toml = toml::to_string_pretty(&r).unwrap();
+        let back: RecentPages = toml::from_str(&toml).unwrap();
+        assert_eq!(back.last_opened("project-a/standup"), Some(42));
+    }
+}

--- a/gui/src/scroll_memory.rs
+++ b/gui/src/scroll_memory.rs
@@ -1,0 +1,87 @@
+//! In-memory scroll-position memory for recently visited notes.
+//!
+//! Remembers the scroll offset of the last few notes the user left, so
+//! navigating back to one — via a link or the picker, not just the back/forward
+//! history — resumes where they were instead of jumping to the top. This is
+//! deliberately not persisted: it only needs to survive within a session.
+
+/// How many notes' scroll positions are retained.
+const CAPACITY: usize = 10;
+
+#[derive(Default)]
+pub struct ScrollMemory {
+    /// (page name, scroll position), most-recently-remembered first.
+    entries: Vec<(String, i32)>,
+}
+
+impl ScrollMemory {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record `pos` for `page`, promoting it to most-recent and evicting the
+    /// least-recently-remembered note once more than [`CAPACITY`] are tracked.
+    pub fn remember(&mut self, page: &str, pos: i32) {
+        self.entries.retain(|(name, _)| name != page);
+        self.entries.insert(0, (page.to_string(), pos));
+        self.entries.truncate(CAPACITY);
+    }
+
+    /// The remembered scroll position for `page`, if it is still tracked.
+    pub fn get(&self, page: &str) -> Option<i32> {
+        self.entries
+            .iter()
+            .find(|(name, _)| name == page)
+            .map(|(_, pos)| *pos)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remembers_and_returns_position() {
+        let mut m = ScrollMemory::new();
+        assert_eq!(m.get("a"), None);
+        m.remember("a", 42);
+        assert_eq!(m.get("a"), Some(42));
+    }
+
+    #[test]
+    fn updates_existing_position() {
+        let mut m = ScrollMemory::new();
+        m.remember("a", 10);
+        m.remember("a", 99);
+        assert_eq!(m.get("a"), Some(99));
+    }
+
+    #[test]
+    fn evicts_least_recently_remembered_beyond_capacity() {
+        let mut m = ScrollMemory::new();
+        for i in 0..CAPACITY {
+            m.remember(&format!("p{i}"), i as i32);
+        }
+        // All CAPACITY notes are still tracked.
+        assert_eq!(m.get("p0"), Some(0));
+
+        // One more evicts the oldest ("p0"); the newest survives.
+        m.remember("new", 123);
+        assert_eq!(m.get("p0"), None);
+        assert_eq!(m.get("new"), Some(123));
+        assert_eq!(m.get("p1"), Some(1));
+    }
+
+    #[test]
+    fn re_remembering_refreshes_recency() {
+        let mut m = ScrollMemory::new();
+        for i in 0..CAPACITY {
+            m.remember(&format!("p{i}"), i as i32);
+        }
+        // Touch the oldest so it is no longer the eviction candidate.
+        m.remember("p0", 7);
+        m.remember("new", 1);
+        assert_eq!(m.get("p0"), Some(7)); // survived
+        assert_eq!(m.get("p1"), None); // evicted instead
+    }
+}

--- a/gui/src/window_state.rs
+++ b/gui/src/window_state.rs
@@ -22,9 +22,31 @@ pub struct WindowGeometry {
     pub fullscreen: bool,
 }
 
-pub fn state_file_path() -> Option<PathBuf> {
+/// Path to a file named `name` inside the application's local data directory.
+/// Used for the window-state file and the page-picker recency store so they
+/// live side by side.
+pub fn data_file(name: &str) -> Option<PathBuf> {
     ProjectDirs::from(QUALIFIER, ORGANIZATION, APPLICATION)
-        .map(|dirs| dirs.data_local_dir().join(STATE_FILE_NAME))
+        .map(|dirs| dirs.data_local_dir().join(name))
+}
+
+pub fn state_file_path() -> Option<PathBuf> {
+    data_file(STATE_FILE_NAME)
+}
+
+/// Path to the page-picker recency store for a specific wiki directory.
+///
+/// Recency is scoped per wiki: the filename embeds a hash of the (canonical)
+/// wiki path so opening notes in one wiki never reorders another wiki's picker.
+pub fn recent_pages_file(wiki_dir: &Path) -> Option<PathBuf> {
+    use std::hash::{Hash, Hasher};
+
+    let canonical = wiki_dir
+        .canonicalize()
+        .unwrap_or_else(|_| wiki_dir.to_path_buf());
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    canonical.hash(&mut hasher);
+    data_file(&format!("recent_pages_{:016x}.toml", hasher.finish()))
 }
 
 pub fn load_state(path: &Path) -> Option<WindowGeometry> {


### PR DESCRIPTION
* The note picker has been reworked and now opens with Cmd-O/Ctrl-O (previously "Go to Page" on Cmd-P/Ctrl-P). With an empty query it lists notes by last-opened date; every row shows a one-line plaintext preview of the note's first paragraphs (Markdown stripped, ellipsized to fit) alongside its last-modification time. Keyboard interaction mirrors VS Code's quick-open: type to filter, move with the arrow keys, or keep the modifier held after opening and tap O again to step the selection down (Shift to go up) — releasing the modifier opens the highlighted note. The currently open note starts selected.

* User-facing wording now says "note" instead of "page": the Page menu is now Note (with New Note … and Open Note …), and the new-note dialog and the status bar ("Note: …") follow suit.

* Returning to a recently visited note now resumes at the scroll position you left it at, rather than jumping to the top — for the last 10 notes, and via any navigation (links, the picker, back/forward). This memory is in-memory only and is not persisted across restarts.

* The note picker now remembers when each note was last opened and persists this per wiki (in the application data directory, keyed by a hash of the wiki's path). The recency ordering therefore survives restarts, and separate wikis opened with --directory keep independenthistories.

