### PR TITLE
New new note behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ While pre-1.0, the minor version is bumped for breaking changes.
   still-unnamed note the dialog opens blank; for a note that already has a name it
   is pre-filled, so the command doubles as a plain rename. Renaming to a name that
   is already taken is refused, and read-only plugin views (e.g. `!index`) cannot
-  be renamed. (#XX)
+  be renamed. (#32)
 - Returning to a recently visited note now resumes at the scroll position you
   left it at, rather than jumping to the top — for the last 10 notes, and via any
   navigation (links, the picker, back/forward). This memory is in-memory only and
@@ -34,7 +34,7 @@ While pre-1.0, the minor version is bumped for breaking changes.
   stopping to name it first; give it a real name afterwards with _Rename Note_
   (`Cmd-S`/`Ctrl-S`). Because an untitled note is only written to disk once you
   type into it, pressing _New Note_ and navigating away leaves no stray files
-  behind. (#XX)
+  behind. (#32)
 - The note picker has been reworked and now opens with `Cmd-O`/`Ctrl-O`
   (previously "Go to Page" on `Cmd-P`/`Ctrl-P`). With an empty query it lists
   notes by last-opened date; every row shows a one-line plaintext preview of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ While pre-1.0, the minor version is bumped for breaking changes.
 
 ### Added
 
+- _Rename Note_ (`Cmd-S`/`Ctrl-S`) renames the currently open note: it moves the
+  note's file on disk and carries the note's navigation history, picker recency,
+  and remembered scroll position over to the new name. For a freshly created,
+  still-unnamed note the dialog opens blank; for a note that already has a name it
+  is pre-filled, so the command doubles as a plain rename. Renaming to a name that
+  is already taken is refused, and read-only plugin views (e.g. `!index`) cannot
+  be renamed. (#XX)
 - Returning to a recently visited note now resumes at the scroll position you
   left it at, rather than jumping to the top — for the last 10 notes, and via any
   navigation (links, the picker, back/forward). This memory is in-memory only and
@@ -21,6 +28,13 @@ While pre-1.0, the minor version is bumped for breaking changes.
 
 ### Changed
 
+- _New Note_ (`Cmd-N`/`Ctrl-N`) no longer asks for a name up front. It now
+  immediately creates and opens an auto-named note (e.g.
+  `untitled_2026-07-04_153412.md`) so a quick thought can be captured without
+  stopping to name it first; give it a real name afterwards with _Rename Note_
+  (`Cmd-S`/`Ctrl-S`). Because an untitled note is only written to disk once you
+  type into it, pressing _New Note_ and navigating away leaves no stray files
+  behind. (#XX)
 - The note picker has been reworked and now opens with `Cmd-O`/`Ctrl-O`
   (previously "Go to Page" on `Cmd-P`/`Ctrl-P`). With an empty query it lists
   notes by last-opened date; every row shows a one-line plaintext preview of the

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -42,14 +42,21 @@ impl DocumentStore {
         DocumentStore { base_path }
     }
 
+    /// Resolve the on-disk path for a page name (with or without a `.md`
+    /// extension), without reading the file. Used e.g. to move a note when
+    /// renaming it.
+    ///
+    /// We deliberately do not rely on `Path::extension`, which would treat the
+    /// trailing part of a dotted page name (e.g. "sprint-q2.6") as the
+    /// extension and skip adding `.md`.
+    pub fn path_for(&self, name: &str) -> PathBuf {
+        self.base_path.join(ensure_md_extension(name))
+    }
+
     /// Load a document by name (with or without .md extension)
     /// If the file doesn't exist, creates an empty document that will be saved on first write
     pub fn load(&self, name: &str) -> Result<Document, String> {
-        // Append `.md` unless the name already carries it. Note we deliberately
-        // do not rely on `Path::extension`, which would treat the trailing part
-        // of a dotted page name (e.g. "sprint-q2.6") as the extension and skip
-        // adding `.md`.
-        let path = self.base_path.join(ensure_md_extension(name));
+        let path = self.path_for(name);
 
         // Read file content and metadata if it exists, otherwise create empty document
         let (content, modified_time) = if path.exists() {
@@ -203,6 +210,26 @@ mod tests {
         assert_eq!(ensure_md_extension("sprint-q2.6"), "sprint-q2.6.md");
         assert_eq!(ensure_md_extension("notes.md"), "notes.md");
         assert_eq!(ensure_md_extension("notes.MD"), "notes.MD");
+    }
+
+    #[test]
+    fn test_path_for_resolves_without_reading() {
+        let store = DocumentStore::new("/tmp/piki-x".into());
+        // `.md` is appended, an existing one is kept, dotted names are preserved,
+        // and nested names keep their separators.
+        assert_eq!(
+            store.path_for("notes"),
+            PathBuf::from("/tmp/piki-x/notes.md")
+        );
+        assert_eq!(
+            store.path_for("notes.md"),
+            PathBuf::from("/tmp/piki-x/notes.md")
+        );
+        assert_eq!(
+            store.path_for("sprint-q2.6"),
+            PathBuf::from("/tmp/piki-x/sprint-q2.6.md")
+        );
+        assert_eq!(store.path_for("a/b"), PathBuf::from("/tmp/piki-x/a/b.md"));
     }
 
     #[test]

--- a/gui/src/history.rs
+++ b/gui/src/history.rs
@@ -52,6 +52,17 @@ impl History {
         self.current_index = Some(self.entries.len() - 1);
     }
 
+    /// Rename every entry that points at `old` to `new`, so back/forward
+    /// navigation follows a note that was renamed instead of resurrecting its
+    /// former (now non-existent) name as an empty note.
+    pub fn rename_page(&mut self, old: &str, new: &str) {
+        for entry in &mut self.entries {
+            if entry.page_name == old {
+                entry.page_name = new.to_string();
+            }
+        }
+    }
+
     /// Update the scroll position of the current entry
     pub fn update_scroll_position(&mut self, scroll_position: i32) {
         if let Some(idx) = self.current_index
@@ -170,6 +181,24 @@ mod tests {
         // Should only keep the last 100
         assert_eq!(history.entries.len(), MAX_HISTORY_SIZE);
         assert_eq!(history.current().unwrap().page_name, "page149");
+    }
+
+    #[test]
+    fn test_rename_page_updates_all_matching_entries() {
+        let mut history = History::new();
+        history.push("untitled_x".to_string(), 0);
+        history.push("other".to_string(), 0);
+        history.push("untitled_x".to_string(), 0);
+
+        history.rename_page("untitled_x", "real-name");
+
+        // Every occurrence of the old name follows the rename; other entries are
+        // untouched.
+        assert_eq!(history.current().unwrap().page_name, "real-name");
+        history.go_back();
+        assert_eq!(history.current().unwrap().page_name, "other");
+        history.go_back();
+        assert_eq!(history.current().unwrap().page_name, "real-name");
     }
 
     #[test]

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -97,6 +97,24 @@ impl AppState {
         }
     }
 
+    /// Update all in-session state that refers to `old` to point at `new` after
+    /// a note has been renamed: the current-page pointer, back/forward history,
+    /// the picker's recency ordering, and remembered scroll positions. The
+    /// on-disk file move is handled by `rename_current_page`.
+    fn rename_page(&mut self, old: &str, new: &str) {
+        if self.current_page == old {
+            self.current_page = new.to_string();
+        }
+        self.history.rename_page(old, new);
+        self.recent_pages.rename(old, new);
+        self.scroll_positions.rename(old, new);
+        if let Some(path) = &self.recent_pages_path
+            && let Err(e) = self.recent_pages.save(path)
+        {
+            eprintln!("Failed to save recent pages: {e}");
+        }
+    }
+
     fn load_page(&mut self, page_name: &str) -> Result<String, String> {
         // Check if this is a plugin page (starts with !)
         if let Some(plugin_name) = page_name.strip_prefix('!') {
@@ -147,6 +165,70 @@ fn save_current_page(
             }
         }
     }
+}
+
+/// Rename the currently open note: move its file on disk and update every piece
+/// of in-session state to follow it. Backs the "Rename Note …" menu item, which
+/// is how a quick, auto-named `untitled_…` note gets a real name.
+///
+/// The current content is flushed to the old file first, so an edit that has not
+/// yet hit the debounced autosave is not lost and there is a file to move. A
+/// brand-new untitled note the user has not typed into has no file yet, so the
+/// move is skipped and the next autosave simply writes to the new name. Returns
+/// an error (surfaced by the dialog) when the target name is already taken or
+/// the move fails; read-only plugin pages ("!…") cannot be renamed.
+fn rename_current_page(
+    new_name: &str,
+    app_state: &Rc<RefCell<AppState>>,
+    autosave_state: &Rc<RefCell<AutoSaveState>>,
+    active_editor: &Rc<RefCell<Rc<RefCell<dyn PageUI>>>>,
+    statusbar: &Rc<RefCell<StatusBar>>,
+) -> Result<(), String> {
+    let new_name = new_name.trim();
+    if new_name.is_empty() {
+        return Err("Please enter a name.".to_string());
+    }
+
+    let old_name = app_state.borrow().current_page.clone();
+    if new_name == old_name {
+        return Ok(());
+    }
+    if old_name.starts_with('!') {
+        return Err("This note cannot be renamed.".to_string());
+    }
+
+    // Flush current content to the old file first, so a not-yet-autosaved edit
+    // is not lost and there is a file to move.
+    save_current_page(app_state, autosave_state, active_editor, statusbar);
+
+    let (old_path, new_path) = {
+        let st = app_state.borrow();
+        (st.store.path_for(&old_name), st.store.path_for(new_name))
+    };
+    if new_path.exists() {
+        return Err(format!("A note named '{new_name}' already exists."));
+    }
+    // A never-typed-into untitled note has no file yet; nothing to move, the new
+    // name is picked up by the next autosave.
+    if old_path.exists() {
+        if let Some(parent) = new_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create folder for '{new_name}': {e}"))?;
+        }
+        std::fs::rename(&old_path, &new_path).map_err(|e| format!("Failed to rename note: {e}"))?;
+    }
+
+    // Point all in-session state at the new name. The editor already holds the
+    // content, so we deliberately do not reload it.
+    app_state.borrow_mut().rename_page(&old_name, new_name);
+    if let Ok(mut as_state) = autosave_state.try_borrow_mut() {
+        as_state.current_page = new_name.to_string();
+    }
+    statusbar
+        .borrow_mut()
+        .set_page(&format!("Note: {new_name}"));
+
+    Ok(())
 }
 
 fn load_page_helper(

--- a/gui/src/menu.rs
+++ b/gui/src/menu.rs
@@ -1,14 +1,15 @@
 use super::{
     AppState, AutoSaveState, load_page_helper, markdown_editor::MarkdownEditor, navigate_back,
-    navigate_forward, page_picker, search_bar::SearchBar, statusbar::StatusBar,
-    window_state::WindowGeometry, wire_editor_callbacks,
+    navigate_forward, page_picker, rename_current_page, search_bar::SearchBar,
+    statusbar::StatusBar, window_state::WindowGeometry, wire_editor_callbacks,
 };
 // Only the non-macOS in-app Quit item saves explicitly; on macOS the system
 // Quit routes through the window Close event, which already saves.
 #[cfg(not(target_os = "macos"))]
 use super::save_current_page;
+use chrono::Local;
 use fltk::{
-    app, button,
+    app, button, dialog,
     enums::{self, Key, Shortcut},
     frame, input, menu,
     prelude::*,
@@ -169,6 +170,7 @@ fn populate_menu<M>(
         Shortcut::Ctrl
     };
     let new_shortcut = cmd | 'n';
+    let rename_shortcut = cmd | 's';
     let gotopage_shortcut = cmd | 'o';
 
     let back_shortcut = if cfg!(target_os = "macos") {
@@ -214,6 +216,31 @@ fn populate_menu<M>(
     let fullscreen_shortcut = cmd | Shortcut::Shift | 'f';
 
     // Page menu
+    // New Note creates an auto-named `untitled_…` note and opens it immediately,
+    // so a quick thought can be captured without first inventing a name; the note
+    // is given a real name later with Rename Note (Cmd-S).
+    {
+        let app_state = app_state.clone();
+        let autosave_state = autosave_state.clone();
+        let active_editor = active_editor.clone();
+        let statusbar = statusbar.clone();
+        menu_bar.add(
+            "Note/New Note",
+            new_shortcut,
+            menu::MenuFlag::Normal,
+            move |_| {
+                load_page_helper(
+                    &default_new_note_name(),
+                    &app_state,
+                    &autosave_state,
+                    &active_editor,
+                    &statusbar,
+                    None,
+                );
+            },
+        );
+    }
+
     {
         let app_state = app_state.clone();
         let autosave_state = autosave_state.clone();
@@ -221,11 +248,11 @@ fn populate_menu<M>(
         let statusbar = statusbar.clone();
         let wind_ref = wind_ref.clone();
         menu_bar.add(
-            "Note/New Note …",
-            new_shortcut,
+            "Note/Rename Note …",
+            rename_shortcut,
             menu::MenuFlag::Normal,
             move |_| {
-                show_new_page_dialog(
+                show_rename_dialog(
                     app_state.clone(),
                     autosave_state.clone(),
                     active_editor.clone(),
@@ -1358,13 +1385,37 @@ fn switch_editor(
     true
 }
 
-fn show_new_page_dialog(
+/// The auto-generated name for a quick new note, e.g.
+/// `untitled_2026-07-04_153412`. Seconds are included so two notes created
+/// within the same minute do not collide onto the same file.
+fn default_new_note_name() -> String {
+    format!("untitled_{}", Local::now().format("%Y-%m-%d_%H%M%S"))
+}
+
+/// Whether `name` is an auto-generated quick-note name (see
+/// [`default_new_note_name`]) that has not been given a real name yet.
+fn is_untitled(name: &str) -> bool {
+    name.starts_with("untitled_")
+}
+
+/// Prompt for a new name for the currently open note and rename it in place
+/// (see [`rename_current_page`]). This is how a quick, auto-named note gets a
+/// real name, but it works on any note.
+fn show_rename_dialog(
     app_state: Rc<RefCell<AppState>>,
     autosave_state: Rc<RefCell<AutoSaveState>>,
     active_editor: Rc<RefCell<Rc<RefCell<dyn PageUI>>>>,
     statusbar: Rc<RefCell<StatusBar>>,
     wind_ref: Rc<RefCell<window::Window>>,
 ) {
+    let current_name = app_state.borrow().current_page.clone();
+
+    // Read-only plugin views (e.g. !index) have no file to rename.
+    if current_name.starts_with('!') {
+        dialog::alert_default("This note cannot be renamed.");
+        return;
+    }
+
     let width = 360;
     let height = 140;
 
@@ -1377,49 +1428,68 @@ fn show_new_page_dialog(
     let pos_x = px + (pw - width) / 2;
     let pos_y = py + (ph - height) / 2;
 
-    let mut win = window::Window::new(pos_x.max(0), pos_y.max(0), width, height, Some("New Note"));
+    let mut win = window::Window::new(
+        pos_x.max(0),
+        pos_y.max(0),
+        width,
+        height,
+        Some("Rename Note"),
+    );
     win.make_modal(true);
     win.begin();
 
-    let mut label = frame::Frame::new(10, 10, width - 20, 24, Some("Enter new note name:"));
+    let mut label = frame::Frame::new(10, 10, width - 20, 24, Some("Rename note to:"));
     label.set_align(enums::Align::Inside | enums::Align::Left);
 
     let mut input = input::Input::new(10, 40, width - 20, 28, None);
+    // Start blank for an unnamed quick note so the user just types a name; for a
+    // note that already has a real name, pre-fill it so this acts as an edit.
+    if !is_untitled(&current_name) {
+        input.set_value(&current_name);
+    }
 
     let mut cancel_btn = button::Button::new(width - 180, height - 40, 80, 30, Some("Cancel"));
-    let mut create_btn = button::ReturnButton::new(width - 90, height - 40, 80, 30, Some("Create"));
-    create_btn.deactivate();
+    let mut rename_btn = button::ReturnButton::new(width - 90, height - 40, 80, 30, Some("Rename"));
+    if input.value().trim().is_empty() {
+        rename_btn.deactivate();
+    }
 
     {
-        let mut create_btn_clone = create_btn.clone();
+        let mut rename_btn_clone = rename_btn.clone();
         input.set_trigger(enums::CallbackTrigger::Changed);
         input.set_callback(move |inp| {
             if inp.value().trim().is_empty() {
-                create_btn_clone.deactivate();
+                rename_btn_clone.deactivate();
             } else {
-                create_btn_clone.activate();
+                rename_btn_clone.activate();
             }
         });
     }
 
-    let input_for_create = input.clone();
+    let input_for_rename = input.clone();
     {
-        let mut win_for_create = win.clone();
-        create_btn.set_callback(move |_| {
-            let name = input_for_create.value().trim().to_string();
+        let mut win_for_rename = win.clone();
+        rename_btn.set_callback(move |_| {
+            let name = input_for_rename.value().trim().to_string();
             if name.is_empty() {
                 return;
             }
 
-            load_page_helper(
+            match rename_current_page(
                 &name,
                 &app_state,
                 &autosave_state,
                 &active_editor,
                 &statusbar,
-                None,
-            );
-            win_for_create.hide();
+            ) {
+                Ok(()) => {
+                    win_for_rename.hide();
+                    app::redraw();
+                }
+                // Keep the dialog open on failure (e.g. the name is taken) so
+                // the user can correct the name.
+                Err(e) => dialog::alert_default(&e),
+            }
         });
     }
 

--- a/gui/src/recency.rs
+++ b/gui/src/recency.rs
@@ -60,6 +60,15 @@ impl RecentPages {
     pub fn last_opened(&self, page: &str) -> Option<i64> {
         self.opened.get(page).copied()
     }
+
+    /// Move `old`'s recency entry to `new` (used when a note is renamed) so the
+    /// renamed note keeps its place in the picker's ordering and no stale entry
+    /// for the vanished name lingers. No-op if `old` was never opened.
+    pub fn rename(&mut self, old: &str, new: &str) {
+        if let Some(time) = self.opened.remove(old) {
+            self.opened.insert(new.to_string(), time);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -72,6 +81,25 @@ mod tests {
         assert_eq!(r.last_opened("x"), None);
         r.mark_opened("x");
         assert!(r.last_opened("x").is_some());
+    }
+
+    #[test]
+    fn rename_moves_entry_preserving_time() {
+        let mut r = RecentPages::default();
+        r.mark_opened("old");
+        let t = r.last_opened("old").unwrap();
+
+        r.rename("old", "new");
+
+        assert_eq!(r.last_opened("old"), None);
+        assert_eq!(r.last_opened("new"), Some(t));
+    }
+
+    #[test]
+    fn rename_unknown_page_is_noop() {
+        let mut r = RecentPages::default();
+        r.rename("missing", "new");
+        assert_eq!(r.last_opened("new"), None);
     }
 
     #[test]

--- a/gui/src/scroll_memory.rs
+++ b/gui/src/scroll_memory.rs
@@ -34,6 +34,14 @@ impl ScrollMemory {
             .find(|(name, _)| name == page)
             .map(|(_, pos)| *pos)
     }
+
+    /// Rename a tracked note in place (used when a note is renamed), preserving
+    /// its remembered position and recency. No-op if `old` is not tracked.
+    pub fn rename(&mut self, old: &str, new: &str) {
+        if let Some((name, _)) = self.entries.iter_mut().find(|(name, _)| name == old) {
+            *name = new.to_string();
+        }
+    }
 }
 
 #[cfg(test)]
@@ -70,6 +78,24 @@ mod tests {
         assert_eq!(m.get("p0"), None);
         assert_eq!(m.get("new"), Some(123));
         assert_eq!(m.get("p1"), Some(1));
+    }
+
+    #[test]
+    fn rename_preserves_position() {
+        let mut m = ScrollMemory::new();
+        m.remember("old", 42);
+        m.rename("old", "new");
+        assert_eq!(m.get("old"), None);
+        assert_eq!(m.get("new"), Some(42));
+    }
+
+    #[test]
+    fn rename_unknown_note_is_noop() {
+        let mut m = ScrollMemory::new();
+        m.remember("a", 1);
+        m.rename("missing", "new");
+        assert_eq!(m.get("new"), None);
+        assert_eq!(m.get("a"), Some(1));
     }
 
     #[test]


### PR DESCRIPTION
_New Note_ (`Cmd-N`/`Ctrl-N`) no longer asks for a name up front. It now  immediately creates and opens an auto-named note (e.g.  `untitled_2026-07-04_153412.md`) so a quick thought can be captured without  stopping to name it first; give it a real name afterwards with _Rename Note_  (`Cmd-S`/`Ctrl-S`). Because an untitled note is only written to disk once you  type into it, pressing _New Note_ and navigating away leaves no stray files  behind.

_Rename Note_ (`Cmd-S`/`Ctrl-S`) renames the currently open note: it moves the note's file on disk and carries the note's navigation history, picker recency,  and remembered scroll position over to the new name. For a freshly created,  still-unnamed note the dialog opens blank; for a note that already has a name it  is pre-filled, so the command doubles as a plain rename. Renaming to a name that  is already taken is refused, and read-only plugin views (e.g. `!index`) cannot  be renamed. 

