### PR TITLE
Fix some Markdown roundtripping issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,15 @@ While pre-1.0, the minor version is bumped for breaking changes.
 
 ### Fixed
 
+- Editing and saving a note no longer corrupts its Markdown in several cases
+  where the text round-tripped incorrectly (via `rutle 0.3.2` and `tdoc 0.11.2`):
+  a styled span that fully contains a shorter differently-styled one
+  (`**bold and <u>underlined</u>**`) is no longer split into pieces, and neither
+  are two adjacent runs that share an outer style (`~~**durch**gestrichen~~`);
+  intra-word italics (`un*frigging*believable`) and adjacent same-style spans are
+  parsed and re-emitted faithfully; code blocks and code spans no longer gain
+  stray blank lines or lose their content; and empty paragraphs (blank lines
+  between blocks) are preserved instead of collapsing.
 - Dragging the scrollbar thumb now tracks the mouse correctly. On long notes the
   thumb was far larger than the target FLTK actually let you grab, so a drag
   registered as a click in the trough and the view jumped the wrong way; the thumb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,19 @@ While pre-1.0, the minor version is bumped for breaking changes.
   so it is clickable from other apps too and reopens Piki at the right section.
   Pasting such a URL into the link editor normalizes it back to a plain
   `note#section` wiki link. Repeated heading titles are disambiguated so a link
-  always resolves to the intended one.
+  always resolves to the intended one. (#36)
+
+### Fixed
+
+- Editing and saving a note no longer corrupts its Markdown in several cases
+  where the text round-tripped incorrectly (via `rutle 0.3.2` and `tdoc 0.11.2`):
+  a styled span that fully contains a shorter differently-styled one
+  (`**bold and <u>underlined</u>**`) is no longer split into pieces, and neither
+  are two adjacent runs that share an outer style (`~~**durch**gestrichen~~`);
+  intra-word italics (`un*frigging*believable`) and adjacent same-style spans are
+  parsed and re-emitted faithfully; code blocks and code spans no longer gain
+  stray blank lines or lose their content; and empty paragraphs (blank lines
+  between blocks) are preserved instead of collapsing. (#37)
 
 ## [0.4.0] - 2026-07-06
 
@@ -103,15 +115,6 @@ While pre-1.0, the minor version is bumped for breaking changes.
 
 ### Fixed
 
-- Editing and saving a note no longer corrupts its Markdown in several cases
-  where the text round-tripped incorrectly (via `rutle 0.3.2` and `tdoc 0.11.2`):
-  a styled span that fully contains a shorter differently-styled one
-  (`**bold and <u>underlined</u>**`) is no longer split into pieces, and neither
-  are two adjacent runs that share an outer style (`~~**durch**gestrichen~~`);
-  intra-word italics (`un*frigging*believable`) and adjacent same-style spans are
-  parsed and re-emitted faithfully; code blocks and code spans no longer gain
-  stray blank lines or lose their content; and empty paragraphs (blank lines
-  between blocks) are preserved instead of collapsing. (#37)
 - Dragging the scrollbar thumb now tracks the mouse correctly. On long notes the
   thumb was far larger than the target FLTK actually let you grab, so a drag
   registered as a click in the trough and the view jumped the wrong way; the thumb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ While pre-1.0, the minor version is bumped for breaking changes.
   intra-word italics (`un*frigging*believable`) and adjacent same-style spans are
   parsed and re-emitted faithfully; code blocks and code spans no longer gain
   stray blank lines or lose their content; and empty paragraphs (blank lines
-  between blocks) are preserved instead of collapsing.
+  between blocks) are preserved instead of collapsing. (#37)
 - Dragging the scrollbar thumb now tracks the mouse correctly. On long notes the
   thumb was far larger than the target FLTK actually let you grab, so a drag
   registered as a click in the trough and the view jumped the wrong way; the thumb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,9 +1300,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rutle"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e328ea0bdb3c60836e9e0a08759855f090589774936ad7708c2759815f6c8e2b"
+checksum = "a14dcb3aac36898ea62a81e0c9c30ce5ebc8f8678227fa2b4411ef3d393a3bf1"
 dependencies = [
  "tdoc",
  "unicode-segmentation",
@@ -1512,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "tdoc"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63729d85e41d192a48b1c7c0ff9e1ad6501b320f01c6b1f8391c934a60fb26d9"
+checksum = "c5848e16c181f71224efacd083b87f4e6d23095bfa5b582d970c39b20a14a180"
 dependencies = [
  "atty",
  "clap",

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 
 [dependencies]
 piki-core = { version = "0.4.0", path = "../core" }
-rutle = "0.3.0"
+rutle = "0.3.2"
 fltk = { version = "1.5.20", features = ["use-wayland"] }
 fltk-sys = "1.5.20"
 pulldown-cmark = "0.13.0"
@@ -31,7 +31,7 @@ toml = "0.9"
 unicode-segmentation = "1.10"
 chrono = "0.4.42"
 arboard = "3.4"
-tdoc = { version="0.11.0", default-features=false }
+tdoc = { version="0.11.2", default-features=false }
 rtf-parser = "0.4"
 webbrowser = { version = "1.2.1", features = ["disable-wsl"] }
 


### PR DESCRIPTION
Editing and saving a note no longer corrupts its Markdown in several cases  where the text round-tripped incorrectly (via `rutle 0.3.2` and `tdoc 0.11.2`):

 a styled span that fully contains a shorter differently-styled one  (`**bold and <u>underlined</u>**`) is no longer split into pieces, and neither  are two adjacent runs that share an outer style (`~~**durch**gestrichen~~`);  intra-word italics (`un*frigging*believable`) and adjacent same-style spans are  parsed and re-emitted faithfully; code blocks and code spans no longer gain  stray blank lines or lose their content; and empty paragraphs (blank lines  between blocks) are preserved instead of collapsing.