### PR TITLE
GUI: Fix handling non-printable control chars

### DIFF
--- a/gui/src/fltk_draw_context.rs
+++ b/gui/src/fltk_draw_context.rs
@@ -1,3 +1,4 @@
+use crate::nonprintable::printable;
 use fltk::{draw as fltk_draw, enums::*, prelude::*};
 use rutle::render_context::{CaretLean, FontStyle, FontType, RenderContext};
 
@@ -64,7 +65,7 @@ impl RenderContext for FltkDrawContext {
     }
 
     fn draw_text(&mut self, text: &str, x: i32, y: i32) {
-        fltk_draw::draw_text(text, x, y);
+        fltk_draw::draw_text(&printable(text), x, y);
     }
 
     fn draw_rect_filled(&mut self, x: i32, y: i32, w: i32, h: i32) {
@@ -116,7 +117,7 @@ impl RenderContext for FltkDrawContext {
 
     fn text_width(&mut self, text: &str, font: FontType, style: FontStyle, size: u8) -> f64 {
         self.set_font(font, style, size);
-        fltk_draw::width(text)
+        fltk_draw::width(&printable(text))
     }
 
     fn text_height(&self, font: FontType, style: FontStyle, size: u8) -> i32 {

--- a/gui/src/fltk_structured_rich_display.rs
+++ b/gui/src/fltk_structured_rich_display.rs
@@ -2,6 +2,7 @@
 
 use crate::clipboard;
 use crate::fltk_draw_context::FltkDrawContext;
+use crate::nonprintable::sanitize_key_text;
 use crate::responsive_scrollbar::ResponsiveScrollbar;
 use fltk::{app::MouseWheel, enums::*, prelude::*};
 use rutle::editor::UndoKind;
@@ -1873,8 +1874,10 @@ impl FltkStructuredRichDisplay {
                                                         }
                                                     }
 
-                                                    if !text_input.is_empty()
-                                                        && editor.insert_text(&text_input).is_ok()
+                                                    let insert_text =
+                                                        sanitize_key_text(&text_input);
+                                                    if !insert_text.is_empty()
+                                                        && editor.insert_text(&insert_text).is_ok()
                                                     {
                                                         text_changed = true;
                                                         did_horizontal = true;

--- a/gui/src/lib.rs
+++ b/gui/src/lib.rs
@@ -9,6 +9,7 @@ pub mod link_editor;
 pub mod link_handler;
 pub mod live_share;
 pub mod markdown_converter;
+pub mod nonprintable;
 pub mod note_ui;
 pub mod on_air_bar;
 pub mod responsive_scrollbar;

--- a/gui/src/live_share.rs
+++ b/gui/src/live_share.rs
@@ -33,6 +33,7 @@ use tiny_http::{Header, Request, Response, Server};
 
 use crate::link_handler::is_external_link;
 use crate::markdown_converter::{document_to_html, markdown_to_document};
+use crate::nonprintable::printable;
 use crate::section_link::{heading_anchors, normalize_link_target, split_target};
 use piki_core::ensure_md_extension;
 use tdoc::{ChecklistItem, Document, InlineStyle, Paragraph, Span};
@@ -314,7 +315,13 @@ fn load_note_markdown(dir: &Path, note: &str) -> Option<String> {
 /// stylesheet can tint it; the document-order-first one also gets `piki-lead`
 /// (the pointing arrow). The browser scrolls the lead into view after swapping.
 fn render_fragment(markdown: &str, highlight: &[HighlightTarget]) -> String {
-    let mut doc = markdown_to_document(markdown);
+    // Show any non-printable character the note carries rather than leaving the
+    // browser to paint its own idea of nothing — the editor does the same, so
+    // viewer and author see the note the same way. Substituted before parsing:
+    // a control character is never Markdown syntax, and the stand-in glyphs are
+    // ordinary text from the parser's point of view.
+    let markdown = printable(markdown);
+    let mut doc = markdown_to_document(&markdown);
     rewrite_links_in_document(&mut doc);
     let anchors = collect_heading_anchors(&doc);
     let sectioned = render_sectioned_html(&doc, highlight);
@@ -1253,6 +1260,15 @@ mod tests {
         assert!(!is_valid_note_name("a//b"));
         assert!(!is_valid_note_name("a\\b"));
         assert!(!is_valid_note_name("a\nb"));
+    }
+
+    #[test]
+    fn renders_non_printable_characters_visibly() {
+        // An ESC that the Escape key typed into a note: the browser paints
+        // nothing for it, so the fragment carries the stand-in glyph instead.
+        let html = render_fragment("Production Depl\u{1b}oyment", &[]);
+        assert!(html.contains("Production Depl\u{241b}oyment"), "{html}");
+        assert!(!html.contains('\u{1b}'), "{html}");
     }
 
     #[test]

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -5,6 +5,7 @@ pub mod fltk_draw_context;
 mod history;
 mod link_handler;
 mod menu;
+pub mod nonprintable;
 mod note_picker;
 mod position_memory;
 mod recency;

--- a/gui/src/nonprintable.rs
+++ b/gui/src/nonprintable.rs
@@ -1,0 +1,115 @@
+//! Handling of characters that have no printable form.
+//!
+//! A control character is the worst kind of stowaway in a note: Quartz paints
+//! nothing for it, yet `fl_width()` still measures a glyph advance — so it
+//! surfaces as a phantom gap in front of the *next* word, in a place the
+//! character isn't, with no way to see it, click it, or aim a Backspace at it.
+//! The same character then travels into the saved Markdown as a raw byte and
+//! into the live-share HTML, where the browser paints its own idea of nothing.
+//!
+//! Two defenses, both here so the notion of "not printable" is defined once:
+//! [`sanitize_key_text`] keeps such a character from entering the document by
+//! keystroke in the first place, and [`printable`] makes any that is already in
+//! one (typed by an older build, pasted, or written by another editor) visible
+//! wherever the document is displayed.
+
+use std::borrow::Cow;
+
+/// A visible stand-in for a character that has no printable form, or `None` if
+/// the character should be shown as-is.
+///
+/// `\n` and `\t` are deliberately left alone: those are real layout whitespace
+/// that the renderer positions itself.
+pub fn control_picture(ch: char) -> Option<char> {
+    match ch {
+        '\n' | '\t' => None,
+        // Unicode Control Pictures: U+2400 + code point, i.e. ␀..␟ (ESC -> ␛).
+        '\u{0}'..='\u{1f}' => char::from_u32(0x2400 + ch as u32),
+        '\u{7f}' => Some('\u{2421}'), // ␡
+        // The C1 controls have no picture of their own; flag them generically.
+        '\u{80}'..='\u{9f}' => Some('\u{fffd}'), // <?>
+        _ => None,
+    }
+}
+
+/// Maps `text` to what should actually be shown, substituting the
+/// [`control_picture`] of every non-printable character. Borrows unchanged in the
+/// overwhelmingly common case that there is nothing to substitute.
+///
+/// The mapping is one char in, one char out, which is what lets a caller apply it
+/// to a substring: measuring `printable(prefix)` still lands where the same
+/// prefix is painted, so line wrapping, caret positions and selection rectangles
+/// all stay consistent with what the user sees.
+pub fn printable(text: &str) -> Cow<'_, str> {
+    if !text.chars().any(|ch| control_picture(ch).is_some()) {
+        return Cow::Borrowed(text);
+    }
+    Cow::Owned(
+        text.chars()
+            .map(|ch| control_picture(ch).unwrap_or(ch))
+            .collect(),
+    )
+}
+
+/// Strips the characters that must never reach the document from a key event's
+/// text.
+///
+/// FLTK fills `Fl::e_text` for *every* key that AppKit routes through
+/// `doCommandBySelector:` — including keys with no editing meaning here — using
+/// the raw character of the event. Escape therefore arrives as `"\u{1b}"` and the
+/// function keys as private-use codepoints (`NSF1FunctionKey` and friends,
+/// `U+F704`..), and inserting either verbatim puts a stowaway in the text.
+///
+/// Line and tab characters are dropped too: Enter and Tab are handled as
+/// structural edits by their own key branches, so anything left here is noise.
+pub fn sanitize_key_text(text: &str) -> String {
+    text.chars()
+        .filter(|ch| !ch.is_control() && !matches!(*ch, '\u{f700}'..='\u{f8ff}'))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{printable, sanitize_key_text};
+    use std::borrow::Cow;
+
+    #[test]
+    fn printable_leaves_ordinary_text_borrowed() {
+        assert!(matches!(printable("Deployment [RL]"), Cow::Borrowed(_)));
+        assert_eq!(printable("Ünïcödé — 😀\tok\n"), "Ünïcödé — 😀\tok\n");
+    }
+
+    #[test]
+    fn printable_substitutes_control_pictures() {
+        // The bug that started this: Escape typed an ESC into a note.
+        assert_eq!(printable("Depl\u{1b}oyment"), "Depl␛oyment");
+        assert_eq!(printable("\u{0}\u{7}\u{1f}"), "␀␇␟");
+        assert_eq!(printable("\u{7f}"), "␡");
+        assert_eq!(printable("\u{85}"), "\u{fffd}");
+    }
+
+    #[test]
+    fn printable_preserves_char_count_so_measurements_stay_aligned() {
+        let text = "a\u{1b}b\u{7f}c";
+        assert_eq!(printable(text).chars().count(), text.chars().count());
+    }
+
+    #[test]
+    fn sanitize_key_text_keeps_ordinary_typed_text() {
+        assert_eq!(sanitize_key_text("a"), "a");
+        assert_eq!(sanitize_key_text("Ünïcödé — ok 😀"), "Ünïcödé — ok 😀");
+        assert_eq!(sanitize_key_text(" "), " ");
+    }
+
+    #[test]
+    fn sanitize_key_text_drops_control_and_function_key_codepoints() {
+        // Escape: FLTK reports the raw character of the event as e_text.
+        assert_eq!(sanitize_key_text("\u{1b}"), "");
+        // Tab/Enter have their own key branches; anything left is noise.
+        assert_eq!(sanitize_key_text("\t"), "");
+        assert_eq!(sanitize_key_text("\r"), "");
+        // NSF1FunctionKey and the rest of AppKit's function-key block.
+        assert_eq!(sanitize_key_text("\u{f704}"), "");
+        assert_eq!(sanitize_key_text("a\u{1b}b"), "ab");
+    }
+}


### PR DESCRIPTION
1. Don't input them in the first place,
2. Render control picture for existing control characters in the text.